### PR TITLE
fix(scorecard): wire SCORECARD_TOKEN for Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,3 @@
----
 # OpenSSF Scorecard for RAG Processor
 # Security posture assessment and supply chain security validation.
 #
@@ -32,3 +31,5 @@ jobs:
       publish-results: true
       upload-sarif: true
       artifact-retention-days: 5
+    secrets:
+      SCORECARD_TOKEN: ${{ secrets.SCORECARD_TOKEN }}


### PR DESCRIPTION
## Summary

- Passes `SCORECARD_TOKEN` org secret into the reusable scorecard workflow so the OpenSSF Branch-Protection check can read branch protection rules
- Unblocks the Scorecard Branch-Protection check, which requires an admin-level token to read `DismissStaleReviews`, `EnforceAdmins`, `RequireLastPushApproval`, `RequiresStatusChecks`, and `UpToDateBeforeMerge` fields

## Dependency

This change requires `ByronWilliamsCPA/.github` PR #41 (now merged) which added the `SCORECARD_TOKEN` secret declaration to the reusable workflow's `workflow_call.secrets:` block. Passing a secret to a reusable workflow that doesn't declare it causes a GitHub Actions error — so the `.github` change had to land first.

## Pre-requisite (manual step)

The `SCORECARD_TOKEN` org secret must be explicitly granted to this repository in GitHub UI before the workflow will have access to it:

> **Settings → Secrets and variables → Actions → SCORECARD_TOKEN → Repository access → add this repo**

## Test plan

- [ ] Grant `SCORECARD_TOKEN` org secret access to this repo
- [ ] Merge this PR
- [ ] Trigger the Scorecard workflow and confirm the Branch-Protection check no longer returns "token insufficient"

Generated with [Claude Code](https://claude.com/claude-code)