### PR TITLE
feat(ci): add qlty coverage upload workflow

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -1,0 +1,28 @@
+name: Qlty
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions: read-all
+
+concurrency:
+  group: qlty-coverage-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  qlty:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-coverage.yml@main
+    permissions:
+      contents: read
+      actions: read
+    with:
+      coverage-artifact-name: coverage-reports
+      coverage-file-path: coverage.xml
+      coverage-format: cobertura
+      workflow-run-id: ${{ github.event.workflow_run.id }}
+    secrets:
+      QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}


### PR DESCRIPTION
Upload test coverage to Qlty Cloud after each successful CI run. Requires \`QLTY_COVERAGE_TOKEN\` secret to be set per-repo at https://qlty.sh/settings/tokens -- the workflow gracefully skips if the token is absent.