### PR TITLE
security: close batch IDOR, harden CORS, pin CI actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,15 @@ LOG_FILE=logs/application.log
 DEBUG=False
 WORKERS=4
 
+# ============================================================================
+# CORS (RAG Processor backend)
+# ============================================================================
+# JSON array of origins the FastAPI backend will trust under
+# allow_credentials=True. Must not be "*". Empty by default so production
+# deployments fail closed; set explicitly below for local dev.
+# Local dev example (Vite on 5173, CRA on 3000, docker frontend on 3000):
+# RAG_PROCESSOR_CORS_ALLOWED_ORIGINS=["http://localhost:5173","http://localhost:3000","http://127.0.0.1:3000","http://frontend:3000"]
+
 # Database Configuration (if applicable)
 # DATABASE_URL=sqlite:///./app.db
 # DATABASE_POOL_SIZE=10

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,11 +26,16 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
           # Deny copyleft licenses that require source disclosure

--- a/SECURITY-FINDINGS.md
+++ b/SECURITY-FINDINGS.md
@@ -1,0 +1,446 @@
+# Security Review — Findings
+
+**Branch**: `claude/security-review-rag-WQL5P`
+**Scope**: React frontend (`frontend/`), FastAPI backend (`src/rag_processor/`), GitHub
+Actions workflows (`.github/workflows/`).
+**Method**: Manual code review against the agreed checklist (XSS/data binding,
+secrets in source, auth on every endpoint, CORS, file upload safety, path
+traversal, injection, CI supply-chain hardening).
+
+Each finding lists severity, where it lives, why it matters, and whether this PR
+applies a fix or leaves a follow-up.
+
+---
+
+## Severity legend
+
+| Tag | Meaning |
+|-----|---------|
+| **CRITICAL** | Direct data exposure / auth bypass exploitable today. |
+| **HIGH** | Material risk under realistic conditions; should ship soon. |
+| **MEDIUM** | Defense-in-depth gap; exploitable only with a second flaw. |
+| **LOW** | Hygiene / hardening recommendation. |
+| **INFO** | Verified safe; documented to prove the check was done. |
+
+---
+
+## 1. Frontend (React) — security checks
+
+### 1.1 [INFO] No unsafe HTML rendering of user-controlled content
+
+**Files reviewed**: `frontend/src/App.tsx`, `frontend/src/components/*.tsx`,
+`frontend/src/hooks/*.ts`.
+
+**Result**: Verified. There are no occurrences of `dangerouslySetInnerHTML`,
+direct `.innerHTML` assignment, or `eval(`. Backend-controlled strings
+(`response.message`, `job.filename`, `user.email`, `health.status`,
+`health.version`, etc.) are rendered as JSX children, which React HTML-escapes
+by default.
+
+```bash
+$ grep -r --include="*.tsx" --include="*.ts" "dangerouslySetInnerHTML\|innerHTML\|eval(" frontend/src/
+(no matches)
+```
+
+The one place that interpolates a backend value into a DOM attribute is
+`frontend/src/components/FileUpload.tsx:198` — `style={{ width: ${uploadProgress}% }}`
+— which is a number from local state, not user-controlled text.
+
+**Action**: None (verified safe).
+
+---
+
+### 1.2 [INFO] No hardcoded API keys or backend URLs in source
+
+**Result**: Verified. The codebase reads API/WebSocket URLs from
+`import.meta.env.VITE_API_URL` only (`useApi.ts:27-29`, `useAuth.ts:12`,
+`useUpload.ts:10`, `useWebSocket.ts:169-171`). `frontend/.env.example` lists the
+expected env vars; no secrets are committed. No tokens of `[A-Za-z0-9_-]{20,}`
+length appear in `frontend/src/`.
+
+**Action**: None (verified safe).
+
+---
+
+### 1.3 [HIGH] WebSocket auth token is passed in the URL query string
+
+**File**: `frontend/src/hooks/useWebSocket.ts:175-182` and
+`src/rag_processor/websocket/router.py:120` (`Query(default=None, alias="token")`).
+
+```ts
+// frontend/src/hooks/useWebSocket.ts
+const params = new URLSearchParams();
+if (token) {
+  params.set('token', token);
+}
+```
+
+The Cloudflare Access JWT is appended as `?token=…` on the
+`wss://…/ws/batch/{id}?token=…` URL. URLs (including query strings) get logged
+in nginx/CDN access logs, are stored in browser history, and may leak via
+`Referer` on subsequent navigations. The token is bearer-equivalent for the
+session it's valid for.
+
+Why not "just use a header"? Browsers cannot set custom headers on the
+`WebSocket` constructor. The accepted patterns are:
+
+1. Have the server set an `HttpOnly` session cookie before the WS upgrade
+   (Cloudflare Access already does this for the application domain).
+2. Accept the WS upgrade, then require the client to send an auth message as
+   the first frame and close the socket if it doesn't arrive within a few
+   seconds.
+
+**Action — applied (defense-in-depth)**: Added owner-check on the WebSocket
+endpoint (see §2.1) so even if the token is exposed, only the batch owner can
+attach. Token-in-URL itself is **left as a follow-up** because moving it off the
+URL touches both client and server message protocols.
+
+---
+
+### 1.4 [MEDIUM] Bearer token in `localStorage`
+
+**File**: `frontend/src/hooks/useApi.ts:41-43, 57`.
+
+```ts
+const token = localStorage.getItem('auth_token')
+if (token) {
+  config.headers.Authorization = `Bearer ${token}`
+}
+```
+
+`localStorage` is reachable from any script that executes in the document; an
+XSS-able vulnerability anywhere in the app or in a dependency would
+exfiltrate the token. The real auth path in this app is Cloudflare Access via
+`HttpOnly` cookies (`withCredentials: true` in `useAuth.ts` and `useUpload.ts`),
+so the `auth_token` codepath in `useApi.ts` appears to be unused legacy code
+from the template.
+
+**Action — left as follow-up**: Recommend removing the localStorage interceptor
+entirely, or moving any future token to an `HttpOnly` cookie. Out of scope for
+this security-only PR because deletion may affect template alignment.
+
+---
+
+## 2. Backend (FastAPI) — auth, CORS, uploads, path traversal
+
+### 2.1 [CRITICAL] Broken object-level authorization on batch/job/WebSocket reads (OWASP A01)
+
+**Files**: `src/rag_processor/api/batch.py` and
+`src/rag_processor/websocket/router.py`.
+
+Before this PR:
+
+```python
+# api/batch.py
+@router.get("/{batch_id}", ...)
+async def get_batch(batch_id: UUID) -> BatchDetailResponse:
+    batch, jobs = get_batch_status(batch_id)
+    if batch is None:
+        raise HTTPException(404, ...)
+    # returns batch regardless of who owns it
+```
+
+`CloudflareAuthMiddleware` enforces *authentication* on `/api/v1/batch/...`
+(it's not in `PUBLIC_PATHS`), but it does **not** enforce *authorization*. Any
+authenticated Cloudflare Access user could read any other user's batch — and
+the WebSocket endpoint had the same gap. Batch IDs are UUIDv4 (≈122 bits of
+entropy), so this isn't easily enumerable, but they appear in URLs, logs, and
+WebSocket connection paths, so leakage is plausible. `Batch` already stores
+`created_by_user_id` / `created_by_email`, so the data needed to check
+ownership is present.
+
+**Fix — applied** (`src/rag_processor/api/batch.py`,
+`src/rag_processor/websocket/router.py`):
+
+- Both REST endpoints now declare `user: CloudflareUser = Depends(get_current_user)`
+  and call a new helper `_user_owns_batch(batch, user)` that matches on
+  `created_by_user_id` (preferred) and falls back to `created_by_email`.
+- WebSocket endpoint replicates the same check before accepting the upgrade.
+- Non-owners receive a 404 (REST) / `WS_1008_POLICY_VIOLATION` (WS) instead of
+  403 so we don't confirm the batch exists. The attempt is logged with
+  `requester_email` and `owner_email` for incident response.
+
+---
+
+### 2.2 [HIGH] CORS configuration was hardcoded; needed env-driven override
+
+**File**: `src/rag_processor/main.py`.
+
+Before:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:5173", ...],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+`allow_origins` was **not** `*`, so the CORS-with-credentials footgun was
+avoided in the committed code. But:
+
+1. There was no way to set production origins without editing source.
+2. `allow_methods=["*"]` and `allow_headers=["*"]` with credentials is broader
+   than needed (FastAPI/Starlette translates `*` to `Access-Control-Allow-*: *`,
+   which browsers reject under `credentials: include`; but the policy is still
+   sloppy and depends on browser behaviour to be safe).
+
+**Fix — applied** (`src/rag_processor/main.py`,
+`src/rag_processor/core/config.py`):
+
+- Added `Settings.cors_allowed_origins`, defaulting to the same dev origins.
+  Production sets `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS` as a JSON array
+  (`["https://app.example.com"]`).
+- `main.py` now reads from settings and **raises at startup** if `"*"` appears
+  in the list, so an insecure-by-misconfiguration deploy fails fast instead of
+  silently allowing any origin.
+- Replaced `allow_methods=["*"]` with the explicit HTTP method list the API
+  uses, and `allow_headers=["*"]` with the explicit headers the frontend sends
+  (including `Cf-Access-Jwt-Assertion` for the JWT header path).
+
+---
+
+### 2.3 [HIGH] `cloudflare_enabled=false` silently authenticates everyone as a fixed dev user
+
+**File**: `src/rag_processor/auth/cloudflare.py:113-117`.
+
+Before:
+
+```python
+if not settings.cloudflare_enabled:
+    request.state.user = self._get_bypass_user()
+    return await call_next(request)
+```
+
+`_get_bypass_user()` returns
+`CloudflareUser(email="dev@localhost", user_id="dev-user-001", groups=["developers"])`.
+The default is `True`, so this is a developer convenience, not an immediate
+exposure — but the failure mode (an env-var typo in prod that flips it to
+`false`) is catastrophic and silent: every request becomes the "developers"
+user.
+
+**Fix — applied**: Bypass mode now emits a `CRITICAL` log on every request
+when active, including the request path. Anyone scraping logs (or alerting on
+CRITICAL) will see the production misconfiguration immediately.
+
+**Follow-up recommendation**: Add a runtime guard that refuses to start with
+`cloudflare_enabled=false` unless an explicit `RAG_PROCESSOR_ALLOW_AUTH_BYPASS=1`
+is also set. Left out of this PR to avoid breaking the existing dev/test flow
+(which relies on the flag).
+
+---
+
+### 2.4 [INFO] File upload endpoint — validation, sanitization, safe storage
+
+**File**: `src/rag_processor/api/ingest.py`.
+
+Verified the upload pipeline:
+
+- **Auth**: `Depends(get_current_user)` is present (line 212).
+- **Size limit**: `settings.max_file_size_bytes` (100 MB default), checked in
+  `validate_file` (line 154). FastAPI also enforces multipart size via Starlette.
+- **Type validation**: MIME type comes from libmagic (`detect_mime_type`,
+  content-based), not from the client-supplied `Content-Type` or extension —
+  good. Allow-list is `settings.allowed_mime_types`.
+- **Filename sanitization**: `sanitize_filename` (line 95) uses
+  `Path(filename).name` to strip path components, then a regex
+  `[^\w\s\-.]` → `_`, then length cap, then a not-empty / not-`.`/`..` check.
+  This resists `../etc/passwd`, NULs, and Windows-style paths.
+- **Storage**: Files are saved under `Path(settings.upload_dir) / str(batch.batch_id) / safe_filename`.
+  The directory component is a server-generated UUID, so a hostile filename
+  cannot collide with another batch. Duplicate-name handling appends `_1`, `_2`
+  rather than overwriting (line 266-270).
+
+**Action**: None (verified safe).
+
+---
+
+### 2.5 [MEDIUM] `validate_file` reads the entire upload into memory before size check
+
+**File**: `src/rag_processor/api/ingest.py:150-160`.
+
+```python
+content = await file.read()
+await file.seek(0)
+if len(content) > settings.max_file_size_bytes:
+    errors.append(...); return content, "", errors
+```
+
+A 1 GB upload (or an attacker sending `Content-Length: huge`) is fully buffered
+in memory **before** the size check rejects it. With `MAX_FILE_SIZE_MB=100` and
+many concurrent uploads, this is a memory-pressure DoS vector.
+
+**Recommendation**: Stream-read in chunks and abort once
+`bytes_read > max_file_size_bytes`. Starlette's `UploadFile.read(size)`
+supports chunked reads. Also consider setting a request body limit via an ASGI
+middleware (e.g., `starlette.middleware.Middleware` with a max-body wrapper).
+
+**Action — left as follow-up**: Non-trivial refactor; the immediate exposure is
+bounded by the rate limiter (60 rpm/IP by default) and the existing 100 MB
+per-file cap.
+
+---
+
+### 2.6 [LOW] Health endpoint leaks Python version (info disclosure)
+
+**File**: `src/rag_processor/api/health.py:36`.
+
+`HealthStatus.python_version` defaults to `sys.version.split()[0]` and is
+served publicly at `/health/live` (in `PUBLIC_PATHS`). Useful for ops; useful
+for attackers correlating CVEs to a specific runtime.
+
+**Recommendation**: Drop `python_version` from the public response (or gate it
+behind an admin-only health endpoint). Low priority — Python versions are easy
+to fingerprint from error pages anyway.
+
+**Action — left as follow-up**.
+
+---
+
+### 2.7 [INFO] No file-content GET endpoint, so no path-traversal read exposure
+
+Searched for endpoints that return file content from disk:
+
+```bash
+$ grep -rn "FileResponse\|send_from_directory\|StreamingResponse.*open" src/
+(no matches)
+```
+
+The only filesystem reads are inside the worker (`process_job_task`), which is
+not user-routable. **No path-traversal on read** because there's no read
+endpoint at all.
+
+**Action**: None.
+
+---
+
+## 3. A03 — Injection
+
+### 3.1 [INFO] No SQL / ORM queries in this service
+
+```bash
+$ grep -rn "execute\|cursor\.execute\|\.sql\|SELECT\|INSERT" src/rag_processor/
+# only hits: utility docstrings, a Sentry SqlalchemyIntegration reference
+```
+
+The gateway persists state in Redis via `rag_processor.queue.redis_store` (key/value
+HGET/HSET; values are typed strings; no `EVAL`/Lua scripts with user input). No
+SQL injection surface in this repo.
+
+---
+
+### 3.2 [INFO] No LLM prompt construction in this service
+
+The processor is a **gateway**: it accepts file uploads, validates them, and
+hands them off to downstream pipelines. There is no chat/RAG-query endpoint
+here; `grep -rn "prompt\|openai\|anthropic" src/` returns nothing. Prompt
+injection is therefore out of scope for this repository and must be reviewed in
+whichever service consumes the routed files (`Pipeline.OCR`,
+`Pipeline.DOC_PROCESSING`, etc.).
+
+**Action**: None for this repo. Owner of downstream pipelines should run a
+separate prompt-injection review against the consumer that builds LLM prompts
+from RAG retrieval results.
+
+---
+
+## 4. GitHub Actions hardening
+
+### 4.1 [HIGH] `sonarsource/sonarqube-quality-gate-action@master` — unpinned, mutable ref
+
+**File**: `.github/workflows/sonarcloud.yml:119`.
+
+`@master` resolves to whatever the upstream maintainer pushes, which is a
+classic supply-chain risk: a compromise of the upstream repo immediately runs
+with this workflow's `SONAR_TOKEN`.
+
+**Fix — applied**: Pinned to
+`sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0`.
+
+---
+
+### 4.2 [MEDIUM] `actions/dependency-review-action@v4` — float-tag, not SHA
+
+**File**: `.github/workflows/dependency-review.yml:33`.
+
+Major-version float-tags (`@v4`) can be moved by the maintainer to any commit
+under the v4 line. Less dangerous than `@master` but still mutable.
+
+**Fix — applied**: Pinned to
+`actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0`.
+
+---
+
+### 4.3 [LOW] Missing `harden-runner` in two workflows
+
+**Files**: `.github/workflows/dependency-review.yml`,
+`.github/workflows/sonarcloud.yml`.
+
+`step-security/harden-runner` is already used by the other workflows
+(`ci.yml`, `cifuzzy.yml`, `codeql.yml`, `pr-validation.yml`,
+`release-sign.yml`, `slsa-provenance.yml`). The two workflows above were
+missing it.
+
+**Fix — applied**: Added a "Harden runner" step with
+`egress-policy: audit` to both workflows (`check-secrets` and `sonarcloud`
+jobs in `sonarcloud.yml`; the single job in `dependency-review.yml`).
+
+---
+
+### 4.4 [INFO] Permissions blocks — all workflows scoped
+
+Spot-check: every top-level workflow file declares a `permissions:` block.
+None default to the GitHub-issued read+write token; most use `contents: read`
+plus the minimum extra scopes required (`security-events: write` for SARIF,
+`pull-requests: write` for PR comments, `id-token: write` for OIDC).
+
+**Action**: None.
+
+---
+
+### 4.5 [LOW] Reusable workflows referenced by mutable `@main`
+
+**Files**: `.github/workflows/ci.yml:32`, `codecov.yml:26`,
+`container-security.yml:42`, `coverage.yml:26`, `docs.yml:32`,
+`mutation-testing.yml:43`, `performance-regression.yml:79`,
+`publish-pypi.yml:20`, `python-compatibility.yml:44`, `qlty.yml:18`,
+`release.yml:47`, `sbom.yml:41`, `scorecard.yml:29`,
+`security-analysis.yml:35`, `slsa-provenance.yml:101`.
+
+All caller workflows reference org-owned reusable workflows by
+`ByronWilliamsCPA/.github/.github/workflows/...@main`. The `pr-validation.yml`
+already pins to a specific SHA — the others should follow.
+
+**Action — left as follow-up**: SHA-pinning these tightens supply chain but
+requires a maintenance process to bump the SHA when the org template changes.
+`pr-validation.yml:35` shows the pattern: `...@b29a870cb21a8f913e5c6c5f08740a4bdd94d0ca  # main`.
+
+---
+
+## Summary of fixes applied in this PR
+
+| # | File | Severity | Change |
+|---|------|----------|--------|
+| 1 | `src/rag_processor/api/batch.py` | CRITICAL | Add auth dependency + ownership check on `GET /batch/{batch_id}` and `GET /batch/job/{job_id}`. Return 404 on non-owner. |
+| 2 | `src/rag_processor/websocket/router.py` | CRITICAL | Add ownership check before accepting WS upgrade for `/ws/batch/{batch_id}`. |
+| 3 | `src/rag_processor/core/config.py` | HIGH | New `cors_allowed_origins` setting (env-overridable via `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS`). |
+| 4 | `src/rag_processor/main.py` | HIGH | Read CORS origins from settings; fail startup on `"*"`; replace `allow_methods=["*"]` / `allow_headers=["*"]` with explicit lists. |
+| 5 | `src/rag_processor/auth/cloudflare.py` | HIGH | Log `CRITICAL` on every request when `cloudflare_enabled=False`. |
+| 6 | `.github/workflows/sonarcloud.yml` | HIGH | Pin `sonarsource/sonarqube-quality-gate-action@master` → SHA `cf038b0e…` (v1.2.0). Add `harden-runner` to both jobs. |
+| 7 | `.github/workflows/dependency-review.yml` | MEDIUM | Pin `actions/dependency-review-action@v4` → SHA `2031cfc0…` (v4.9.0). Add `harden-runner`. |
+
+## Follow-ups (not in this PR)
+
+- §1.3: Move WebSocket auth token off the URL onto an `HttpOnly` cookie or
+  post-accept message.
+- §1.4: Delete the unused `localStorage` bearer-token interceptor in
+  `useApi.ts`.
+- §2.3: Guard `cloudflare_enabled=False` behind an explicit
+  `RAG_PROCESSOR_ALLOW_AUTH_BYPASS=1` to make production bypass a two-flag
+  decision.
+- §2.5: Stream-read uploads and abort over `max_file_size_bytes` instead of
+  buffering the whole body.
+- §2.6: Drop Python version from public `/health/live` responses.
+- §4.5: SHA-pin org-owned reusable workflow callouts.

--- a/SECURITY-FINDINGS.md
+++ b/SECURITY-FINDINGS.md
@@ -456,10 +456,15 @@ project's 120-char markdown limit.)
    a production deploy accidentally running in bypass mode is visible in
    logs / alerting immediately.
 
-6. **[HIGH]** `.github/workflows/sonarcloud.yml`
-   Pin `sonarsource/sonarqube-quality-gate-action@master` → SHA
-   `cf038b0e…` (v1.2.0). Add `harden-runner` (egress-policy: audit) to
-   both jobs.
+6. **[HIGH]** `.github/workflows/sonarcloud.yml` (mooted by main)
+   Pinned `sonarsource/sonarqube-quality-gate-action@master` → SHA
+   `cf038b0e…` (v1.2.0) and added `harden-runner` (egress-policy:
+   audit) to both jobs in this PR's first commit. **After this PR was
+   opened, main merged #27 (`4055d57`) which replaced this file with a
+   call to an org-level reusable workflow.** The merge will resolve in
+   favor of main, so the SHA-pin lands via the org workflow rather
+   than via this PR's diff. Audit trail: the SHA-pin requirement was
+   met; the file change itself will be overwritten.
 
 7. **[MEDIUM]** `.github/workflows/dependency-review.yml`
    Pin `actions/dependency-review-action@v4` → SHA `2031cfc0…` (v4.9.0).
@@ -478,3 +483,11 @@ project's 120-char markdown limit.)
   buffering the whole body.
 - §2.6: Drop Python version from public `/health/live` responses.
 - §4.5: SHA-pin org-owned reusable workflow callouts.
+- **Tighten `batch_is_owned_by` email fallback**: `auth/dependencies.py`
+  currently falls back to email match when either side lacks `user_id` so
+  that batches created before Cloudflare Access populated `sub` claims
+  remain readable. Once all batches have `created_by_user_id`, drop the
+  email fallback so an attacker who obtains a token for an email that
+  matches a legacy batch owner cannot read that batch. Tracking task: gate
+  the fallback on a `LEGACY_BATCH_EMAIL_FALLBACK` setting that defaults to
+  False once the data migration completes.

--- a/SECURITY-FINDINGS.md
+++ b/SECURITY-FINDINGS.md
@@ -425,15 +425,45 @@ requires a maintenance process to bump the SHA when the org template changes.
 
 ## Summary of fixes applied in this PR
 
-| # | File | Severity | Change |
-|---|------|----------|--------|
-| 1 | `src/rag_processor/api/batch.py` | CRITICAL | Add auth dependency + ownership check on `GET /batch/{batch_id}` and `GET /batch/job/{job_id}`. Return 404 on non-owner. |
-| 2 | `src/rag_processor/websocket/router.py` | CRITICAL | Add ownership check before accepting WS upgrade for `/ws/batch/{batch_id}`. |
-| 3 | `src/rag_processor/core/config.py` | HIGH | New `cors_allowed_origins` setting (env-overridable via `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS`). |
-| 4 | `src/rag_processor/main.py` | HIGH | Read CORS origins from settings; fail startup on `"*"`; replace `allow_methods=["*"]` / `allow_headers=["*"]` with explicit lists. |
-| 5 | `src/rag_processor/auth/cloudflare.py` | HIGH | Log `CRITICAL` on every request when `cloudflare_enabled=False`. |
-| 6 | `.github/workflows/sonarcloud.yml` | HIGH | Pin `sonarsource/sonarqube-quality-gate-action@master` → SHA `cf038b0e…` (v1.2.0). Add `harden-runner` to both jobs. |
-| 7 | `.github/workflows/dependency-review.yml` | MEDIUM | Pin `actions/dependency-review-action@v4` → SHA `2031cfc0…` (v4.9.0). Add `harden-runner`. |
+(Each entry: file — severity — change. Bulleted to keep lines under the
+project's 120-char markdown limit.)
+
+1. **[CRITICAL]** `src/rag_processor/api/batch.py`
+   Add auth dependency + ownership check on `GET /batch/{batch_id}` and
+   `GET /batch/job/{job_id}`. Non-owners receive 404 (not 403) so batch
+   existence isn't leaked. Ownership logic centralised in
+   `auth/dependencies.py::batch_is_owned_by` with user_id-takes-precedence
+   semantics (matching email cannot override a mismatched user_id).
+   Warning logs include only opaque IDs — no PII (per CodeRabbit review).
+
+2. **[CRITICAL]** `src/rag_processor/websocket/router.py`
+   Add ownership check before accepting WS upgrade for `/ws/batch/{batch_id}`.
+   Uses the same `batch_is_owned_by` helper so the WS authz path cannot
+   diverge from the REST authz path. Warning logs redacted to opaque IDs.
+
+3. **[HIGH]** `src/rag_processor/core/config.py`, `.env.example`
+   New `cors_allowed_origins` setting, **empty by default** so production
+   fails closed. Overridable via `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS` as a
+   JSON array; dev value documented in `.env.example`.
+
+4. **[HIGH]** `src/rag_processor/main.py`
+   Read CORS origins from settings; **raise at startup** on `"*"`; replace
+   `allow_methods=["*"]` / `allow_headers=["*"]` with explicit method and
+   header lists (the latter including `Cf-Access-Jwt-Assertion`).
+
+5. **[HIGH]** `src/rag_processor/auth/cloudflare.py`
+   Emit a `CRITICAL` log on every request when `cloudflare_enabled=False` so
+   a production deploy accidentally running in bypass mode is visible in
+   logs / alerting immediately.
+
+6. **[HIGH]** `.github/workflows/sonarcloud.yml`
+   Pin `sonarsource/sonarqube-quality-gate-action@master` → SHA
+   `cf038b0e…` (v1.2.0). Add `harden-runner` (egress-policy: audit) to
+   both jobs.
+
+7. **[MEDIUM]** `.github/workflows/dependency-review.yml`
+   Pin `actions/dependency-review-action@v4` → SHA `2031cfc0…` (v4.9.0).
+   Add `harden-runner`.
 
 ## Follow-ups (not in this PR)
 

--- a/SECURITY-FINDINGS.md
+++ b/SECURITY-FINDINGS.md
@@ -188,11 +188,15 @@ avoided in the committed code. But:
    sloppy and depends on browser behaviour to be safe).
 
 **Fix — applied** (`src/rag_processor/main.py`,
-`src/rag_processor/core/config.py`):
+`src/rag_processor/core/config.py`, `.env.example`):
 
-- Added `Settings.cors_allowed_origins`, defaulting to the same dev origins.
-  Production sets `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS` as a JSON array
-  (`["https://app.example.com"]`).
+- Added `Settings.cors_allowed_origins`, **empty by default** so the backend
+  fails closed when deployed without explicit configuration. Both dev and prod
+  set `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS` as a JSON array
+  (`["https://app.example.com"]` in prod, the localhost set in dev — see
+  `.env.example`). Empty default also resolves SonarCloud python:S5332,
+  which (correctly) flagged the previous hardcoded `http://localhost:*`
+  defaults as insecure plaintext URLs in production source.
 - `main.py` now reads from settings and **raises at startup** if `"*"` appears
   in the list, so an insecure-by-misconfiguration deploy fails fast instead of
   silently allowing any origin.

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -11,10 +11,9 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from rag_processor.auth.dependencies import get_current_user
+from rag_processor.auth.dependencies import batch_is_owned_by, get_current_user
 from rag_processor.auth.models import CloudflareUser
 from rag_processor.models.batch import (
-    Batch,
     BatchStatus,
 )
 from rag_processor.models.job import (
@@ -28,25 +27,6 @@ from rag_processor.utils.logging import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/batch", tags=["batch"])
-
-
-def _user_owns_batch(batch: Batch, user: CloudflareUser) -> bool:
-    """Check whether the authenticated user owns this batch.
-
-    Owners are matched by Cloudflare user ID (preferred) or email (fallback for
-    batches created before user_id was populated). Mismatched/empty IDs do not
-    grant access.
-
-    Args:
-        batch: The batch being accessed.
-        user: The authenticated caller.
-
-    Returns:
-        True if the caller created the batch.
-    """
-    if batch.created_by_user_id and user.user_id:
-        return batch.created_by_user_id == user.user_id
-    return bool(batch.created_by_email) and batch.created_by_email == user.email
 
 
 class JobDetailResponse(BaseModel):
@@ -148,14 +128,17 @@ async def get_batch(
     batch, jobs = get_batch_status(batch_id)
 
     # Return 404 (not 403) for non-owners to avoid leaking batch existence.
-    if batch is None or not _user_owns_batch(batch, user):
+    if batch is None or not batch_is_owned_by(
+        batch, requester_user_id=user.user_id, requester_email=user.email
+    ):
         if batch is not None:
+            # Minimal log context: opaque IDs only. Don't include the requester
+            # email or the owner's email/identity (attacker-controlled probes
+            # could otherwise extract owner info from logs).
             logger.warning(
                 "Unauthorized batch access attempt",
                 batch_id=str(batch_id),
-                requester_email=user.email,
                 requester_user_id=user.user_id,
-                owner_email=batch.created_by_email,
             )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -241,15 +224,16 @@ async def get_job(
 
     # A job inherits ownership from its parent batch.
     batch, _ = get_batch_status(job.batch_id)
-    if batch is None or not _user_owns_batch(batch, user):
+    if batch is None or not batch_is_owned_by(
+        batch, requester_user_id=user.user_id, requester_email=user.email
+    ):
         if batch is not None:
+            # Minimal log context: opaque IDs only. See note in get_batch.
             logger.warning(
                 "Unauthorized job access attempt",
                 job_id=str(job_id),
                 batch_id=str(job.batch_id),
-                requester_email=user.email,
                 requester_user_id=user.user_id,
-                owner_email=batch.created_by_email,
             )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from rag_processor.auth.dependencies import get_current_user
+from rag_processor.auth.models import CloudflareUser
 from rag_processor.models.batch import (
+    Batch,
     BatchStatus,
 )
 from rag_processor.models.job import (
@@ -24,6 +27,25 @@ from rag_processor.utils.logging import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/batch", tags=["batch"])
+
+
+def _user_owns_batch(batch: Batch, user: CloudflareUser) -> bool:
+    """Check whether the authenticated user owns this batch.
+
+    Owners are matched by Cloudflare user ID (preferred) or email (fallback for
+    batches created before user_id was populated). Mismatched/empty IDs do not
+    grant access.
+
+    Args:
+        batch: The batch being accessed.
+        user: The authenticated caller.
+
+    Returns:
+        True if the caller created the batch.
+    """
+    if batch.created_by_user_id and user.user_id:
+        return batch.created_by_user_id == user.user_id
+    return bool(batch.created_by_email) and batch.created_by_email == user.email
 
 
 class JobDetailResponse(BaseModel):
@@ -100,7 +122,10 @@ class BatchDetailResponse(BaseModel):
         404: {"description": "Batch not found"},
     },
 )
-async def get_batch(batch_id: UUID) -> BatchDetailResponse:
+async def get_batch(
+    batch_id: UUID,
+    user: CloudflareUser = Depends(get_current_user),
+) -> BatchDetailResponse:
     """Get batch status and job list.
 
     Returns the current status of a batch and a detail record for every
@@ -111,16 +136,26 @@ async def get_batch(batch_id: UUID) -> BatchDetailResponse:
 
     Args:
         batch_id: Batch identifier (UUID).
+        user: Authenticated user from Cloudflare Access.
 
     Returns:
         BatchDetailResponse with batch metadata and the list of jobs.
 
     Raises:
-        HTTPException: 404 if no batch with the given ID exists.
+        HTTPException: 404 if batch not found or caller does not own it.
     """
     batch, jobs = get_batch_status(batch_id)
 
-    if batch is None:
+    # Return 404 (not 403) for non-owners to avoid leaking batch existence.
+    if batch is None or not _user_owns_batch(batch, user):
+        if batch is not None:
+            logger.warning(
+                "Unauthorized batch access attempt",
+                batch_id=str(batch_id),
+                requester_email=user.email,
+                requester_user_id=user.user_id,
+                owner_email=batch.created_by_email,
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Batch {batch_id} not found",
@@ -173,7 +208,10 @@ async def get_batch(batch_id: UUID) -> BatchDetailResponse:
         404: {"description": "Job not found"},
     },
 )
-async def get_job(job_id: UUID) -> JobDetailResponse:
+async def get_job(
+    job_id: UUID,
+    user: CloudflareUser = Depends(get_current_user),
+) -> JobDetailResponse:
     """Get job status and details.
 
     Returns the current state of a single processing job, including the
@@ -184,16 +222,34 @@ async def get_job(job_id: UUID) -> JobDetailResponse:
 
     Args:
         job_id: Job identifier (UUID).
+        user: Authenticated user from Cloudflare Access.
 
     Returns:
         JobDetailResponse with job metadata and processing state.
 
     Raises:
-        HTTPException: 404 if no job with the given ID exists.
+        HTTPException: 404 if job not found or caller does not own its batch.
     """
     job = get_job_status(job_id)
 
     if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job {job_id} not found",
+        )
+
+    # A job inherits ownership from its parent batch.
+    batch, _ = get_batch_status(job.batch_id)
+    if batch is None or not _user_owns_batch(batch, user):
+        if batch is not None:
+            logger.warning(
+                "Unauthorized job access attempt",
+                job_id=str(job_id),
+                batch_id=str(job.batch_id),
+                requester_email=user.email,
+                requester_user_id=user.user_id,
+                owner_email=batch.created_by_email,
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Job {job_id} not found",

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -5,6 +5,7 @@ Provides endpoints for querying batch and job status.
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -124,7 +125,7 @@ class BatchDetailResponse(BaseModel):
 )
 async def get_batch(
     batch_id: UUID,
-    user: CloudflareUser = Depends(get_current_user),
+    user: Annotated[CloudflareUser, Depends(get_current_user)],
 ) -> BatchDetailResponse:
     """Get batch status and job list.
 
@@ -210,7 +211,7 @@ async def get_batch(
 )
 async def get_job(
     job_id: UUID,
-    user: CloudflareUser = Depends(get_current_user),
+    user: Annotated[CloudflareUser, Depends(get_current_user)],
 ) -> JobDetailResponse:
     """Get job status and details.
 

--- a/src/rag_processor/auth/cloudflare.py
+++ b/src/rag_processor/auth/cloudflare.py
@@ -113,8 +113,16 @@ class CloudflareAuthMiddleware(BaseHTTPMiddleware):
         if self._is_public_path(request.url.path):
             return await call_next(request)
 
-        # Bypass mode for local development
+        # Bypass mode for local development. This grants every request a fixed
+        # mock identity with the "developers" group, so it must never be enabled
+        # in production. Log a critical warning on every request to make
+        # misconfiguration obvious in production logs.
         if not settings.cloudflare_enabled:
+            logger.critical(
+                "Cloudflare auth is DISABLED - all requests are authenticated as "
+                "the bypass user. This must only be used for local development.",
+                path=request.url.path,
+            )
             request.state.user = self._get_bypass_user()
             return await call_next(request)
 

--- a/src/rag_processor/auth/dependencies.py
+++ b/src/rag_processor/auth/dependencies.py
@@ -6,11 +6,14 @@ in protected endpoints.
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from fastapi import HTTPException, Request, status
 
 from rag_processor.auth.models import CloudflareUser
+
+if TYPE_CHECKING:
+    from rag_processor.models.batch import Batch
 
 
 async def get_current_user(request: Request) -> CloudflareUser:
@@ -43,6 +46,40 @@ async def get_current_user(request: Request) -> CloudflareUser:
             headers={"WWW-Authenticate": "Bearer"},
         )
     return user
+
+
+def batch_is_owned_by(
+    batch: Batch,
+    *,
+    requester_user_id: str | None,
+    requester_email: str | None,
+) -> bool:
+    """Check whether the caller owns the given batch.
+
+    Ownership precedence:
+    1. If both the batch and the caller have a Cloudflare user_id, that must
+       match. Email is NOT checked as a fallback in this case — a different
+       user_id with a coincidentally matching email must not grant access.
+    2. Otherwise (legacy batches without user_id, or callers without one),
+       fall back to email match.
+
+    Empty strings on either side never grant access.
+
+    Keyword-only requester args so REST callers (which have a CloudflareUser)
+    and WebSocket callers (which only have a dict from verify_cloudflare_token)
+    can both pass primitives without constructing a model.
+
+    Args:
+        batch: The batch being accessed.
+        requester_user_id: The caller's Cloudflare user ID (sub), or None.
+        requester_email: The caller's email, or None.
+
+    Returns:
+        True if the caller created the batch.
+    """
+    if batch.created_by_user_id and requester_user_id:
+        return batch.created_by_user_id == requester_user_id
+    return bool(batch.created_by_email) and batch.created_by_email == requester_email
 
 
 async def get_optional_user(request: Request) -> CloudflareUser | None:

--- a/src/rag_processor/core/config.py
+++ b/src/rag_processor/core/config.py
@@ -55,17 +55,20 @@ class Settings(BaseSettings):
     )
 
     # CORS
+    # Empty by default so production deployments must opt in explicitly via
+    # RAG_PROCESSOR_CORS_ALLOWED_ORIGINS. The previous version of this setting
+    # shipped dev http://localhost origins as defaults, which SonarCloud S5332
+    # flagged for the obvious reason that they're plaintext http; more
+    # importantly, baked-in defaults make it too easy to ship a production
+    # build that accidentally trusts dev origins.
+    # Local dev: see .env.example / docs for the recommended dev value.
     cors_allowed_origins: list[str] = Field(
-        default=[
-            "http://localhost:3000",
-            "http://localhost:5173",
-            "http://127.0.0.1:3000",
-            "http://frontend:3000",
-        ],
+        default_factory=list,
         description=(
             "Allowed CORS origins. Must be an explicit list of origins (no "
-            "wildcard) because allow_credentials=True. Override in production via "
-            "RAG_PROCESSOR_CORS_ALLOWED_ORIGINS as a JSON array."
+            "wildcard) because allow_credentials=True. Set via "
+            "RAG_PROCESSOR_CORS_ALLOWED_ORIGINS as a JSON array; empty by "
+            "default."
         ),
     )
 

--- a/src/rag_processor/core/config.py
+++ b/src/rag_processor/core/config.py
@@ -54,6 +54,21 @@ class Settings(BaseSettings):
         description="Enable Cloudflare authentication (set to false for local dev)",
     )
 
+    # CORS
+    cors_allowed_origins: list[str] = Field(
+        default=[
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:3000",
+            "http://frontend:3000",
+        ],
+        description=(
+            "Allowed CORS origins. Must be an explicit list of origins (no "
+            "wildcard) because allow_credentials=True. Override in production via "
+            "RAG_PROCESSOR_CORS_ALLOWED_ORIGINS as a JSON array."
+        ),
+    )
+
     # Rate Limiting
     rate_limiting_enabled: bool = Field(
         default=True,

--- a/src/rag_processor/main.py
+++ b/src/rag_processor/main.py
@@ -79,20 +79,30 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Add CORS middleware (must be added before other middleware)
-# CORS origins are configured for local development. For production,
-# use environment variables or Cloudflare Access to control origins.
+# Add CORS middleware (must be added before other middleware).
+# Origins come from settings so production deployments can override via
+# RAG_PROCESSOR_CORS_ALLOWED_ORIGINS. Wildcard "*" is forbidden because we send
+# credentials; reject it loudly rather than silently producing an insecure config.
+_cors_origins = list(settings.cors_allowed_origins)
+if "*" in _cors_origins:
+    msg = (
+        "CORS allow_origins=['*'] is not permitted with allow_credentials=True. "
+        "Set RAG_PROCESSOR_CORS_ALLOWED_ORIGINS to an explicit list of origins."
+    )
+    raise RuntimeError(msg)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "http://localhost:5173",  # Vite dev server
-        "http://127.0.0.1:3000",
-        "http://frontend:3000",  # Docker service name
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-Correlation-ID",
+        "X-Request-ID",
+        "Cf-Access-Jwt-Assertion",
+    ],
     expose_headers=["X-Correlation-ID", "X-Request-ID"],
 )
 

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -34,17 +34,34 @@ async def verify_ws_token(token: str | None) -> dict[str, str] | None:
         User info dict if valid, None otherwise.
     """
     if not settings.cloudflare_enabled:
-        # Auth disabled, return mock user
-        return {"email": "anonymous@local", "user_id": "local"}
+        # Bypass mode. The returned identity MUST match
+        # CloudflareAuthMiddleware._get_bypass_user() so that a batch created
+        # over HTTP in dev mode can be subscribed to over WebSocket. (Previously
+        # this returned "anonymous@local" / "local" which broke ownership
+        # checks after batch_is_owned_by was introduced.) Mirror the middleware's
+        # CRITICAL log so production misconfiguration is loud on every WS upgrade.
+        logger.critical(
+            "Cloudflare auth is DISABLED - WebSocket upgrade authenticated "
+            "as bypass user. This must only be used for local development.",
+        )
+        return {"email": "dev@localhost", "user_id": "dev-user-001"}
 
     if not token:
         return None
 
     try:
-        # Verify token with Cloudflare
+        # Verify token with Cloudflare.
         return await verify_cloudflare_token(token)
     except (jwt.InvalidTokenError, jwt.ExpiredSignatureError) as e:
         logger.warning("WebSocket token verification failed", error=str(e))
+        return None
+    except Exception as e:  # noqa: BLE001
+        # JWKS fetch failures (httpx.ConnectError, TimeoutException,
+        # HTTPStatusError) and json.JSONDecodeError aren't JWT exceptions and
+        # would otherwise propagate, closing the WS with 1011 (internal error)
+        # instead of 1008 (policy violation). Mirror the HTTP middleware which
+        # already handles this with a broad except.
+        logger.warning("WebSocket token verification error", error=str(e))
         return None
 
 
@@ -169,7 +186,7 @@ async def websocket_batch_status(
     logger.info(
         "WebSocket connection established",
         batch_id=str(batch_id),
-        user_email=user.get("email"),
+        requester_user_id=requester_user_id,
     )
 
     try:

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -12,6 +12,7 @@ import jwt
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, status
 
 from rag_processor.auth.cloudflare import verify_cloudflare_token
+from rag_processor.auth.dependencies import batch_is_owned_by
 from rag_processor.core.config import settings
 from rag_processor.queue.jobs import get_batch_status
 from rag_processor.utils.logging import get_logger
@@ -144,24 +145,20 @@ async def websocket_batch_status(
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
-    requester_email = user.get("email")
-    requester_user_id = user.get("user_id")
-    owns_by_id = (
-        bool(batch.created_by_user_id)
-        and bool(requester_user_id)
-        and (batch.created_by_user_id == requester_user_id)
-    )
-    owns_by_email = (
-        bool(batch.created_by_email)
-        and bool(requester_email)
-        and (batch.created_by_email == requester_email)
-    )
-    if not (owns_by_id or owns_by_email):
+    # Shared ownership helper. user_id-takes-precedence semantics: a matching
+    # email with a mismatched user_id is NOT enough to grant access.
+    requester_user_id = user.get("user_id") or None
+    requester_email = user.get("email") or None
+    if not batch_is_owned_by(
+        batch,
+        requester_user_id=requester_user_id,
+        requester_email=requester_email,
+    ):
+        # Minimal log context: opaque IDs only. Don't leak owner identity.
         logger.warning(
             "Unauthorized WebSocket batch access attempt",
             batch_id=str(batch_id),
-            requester_email=requester_email,
-            owner_email=batch.created_by_email,
+            requester_user_id=requester_user_id,
         )
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -137,9 +137,28 @@ async def websocket_batch_status(
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
-    # Verify batch exists
+    # Verify batch exists and the caller owns it. Treat "not found" and
+    # "not authorized" identically to avoid leaking batch IDs.
     batch, _ = get_batch_status(batch_id)
     if batch is None:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    requester_email = user.get("email")
+    requester_user_id = user.get("user_id")
+    owns_by_id = bool(batch.created_by_user_id) and bool(requester_user_id) and (
+        batch.created_by_user_id == requester_user_id
+    )
+    owns_by_email = bool(batch.created_by_email) and bool(requester_email) and (
+        batch.created_by_email == requester_email
+    )
+    if not (owns_by_id or owns_by_email):
+        logger.warning(
+            "Unauthorized WebSocket batch access attempt",
+            batch_id=str(batch_id),
+            requester_email=requester_email,
+            owner_email=batch.created_by_email,
+        )
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -146,11 +146,15 @@ async def websocket_batch_status(
 
     requester_email = user.get("email")
     requester_user_id = user.get("user_id")
-    owns_by_id = bool(batch.created_by_user_id) and bool(requester_user_id) and (
-        batch.created_by_user_id == requester_user_id
+    owns_by_id = (
+        bool(batch.created_by_user_id)
+        and bool(requester_user_id)
+        and (batch.created_by_user_id == requester_user_id)
     )
-    owns_by_email = bool(batch.created_by_email) and bool(requester_email) and (
-        batch.created_by_email == requester_email
+    owns_by_email = (
+        bool(batch.created_by_email)
+        and bool(requester_email)
+        and (batch.created_by_email == requester_email)
     )
     if not (owns_by_id or owns_by_email):
         logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,16 @@ os.environ.setdefault("RAG_PROCESSOR_RATE_LIMITING_ENABLED", "false")
 # Auth middleware tests explicitly enable it when needed
 os.environ.setdefault("RAG_PROCESSOR_CLOUDFLARE_ENABLED", "false")
 
+# CORS origins are now empty-by-default in production (see config.py /
+# SECURITY-FINDINGS.md §2.2). Tests need explicit dev origins so the CORS
+# integration test can verify the middleware actually emits
+# Access-Control-Allow-Origin. Must be set before the app is imported.
+os.environ.setdefault(
+    "RAG_PROCESSOR_CORS_ALLOWED_ORIGINS",
+    '["http://localhost:3000","http://localhost:5173",'
+    '"http://127.0.0.1:3000","http://frontend:3000"]',
+)
+
 # ============================================================================
 # Test Fixture Paths
 # ============================================================================

--- a/tests/unit/test_batch_authz.py
+++ b/tests/unit/test_batch_authz.py
@@ -1,0 +1,206 @@
+"""Authorization tests for batch and job read endpoints.
+
+These tests exercise the ownership check added in
+src/rag_processor/api/batch.py so SonarCloud / Codecov see the new branches as
+covered. We don't use the running TestClient transport here because that
+requires booting the auth middleware and Redis; instead we drive the handler
+functions directly with mocks for `get_batch_status` / `get_job_status`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from rag_processor.api.batch import _user_owns_batch, get_batch, get_job
+from rag_processor.auth.models import CloudflareUser
+from rag_processor.models.batch import Batch, BatchStatus
+from rag_processor.models.job import (
+    FileClassification,
+    Job,
+    JobStatus,
+    Pipeline,
+)
+
+
+def _user(
+    email: str = "owner@example.com", user_id: str | None = "u-1"
+) -> CloudflareUser:
+    now = datetime.now(tz=UTC)
+    return CloudflareUser(
+        email=email,
+        user_id=user_id,
+        groups=[],
+        issued_at=now,
+        expires_at=now,
+    )
+
+
+def _batch(
+    *,
+    created_by_email: str = "owner@example.com",
+    created_by_user_id: str | None = "u-1",
+) -> Batch:
+    return Batch(
+        batch_id=uuid4(),
+        created_by_email=created_by_email,
+        created_by_user_id=created_by_user_id,
+        status=BatchStatus.QUEUED,
+        total_files=1,
+    )
+
+
+def _job(batch_id) -> Job:
+    return Job(
+        job_id=uuid4(),
+        batch_id=batch_id,
+        filename="x.pdf",
+        file_path="/tmp/x.pdf",
+        file_type="application/pdf",
+        file_size_bytes=10,
+        status=JobStatus.QUEUED,
+        classification=FileClassification.BORN_DIGITAL_PDF,
+        routed_to=Pipeline.DOC_PROCESSING,
+    )
+
+
+class TestUserOwnsBatch:
+    """Direct tests for the ownership helper."""
+
+    def test_matches_on_user_id(self):
+        assert _user_owns_batch(_batch(), _user()) is True
+
+    def test_user_id_mismatch_rejects(self):
+        assert (
+            _user_owns_batch(_batch(created_by_user_id="someone-else"), _user())
+            is False
+        )
+
+    def test_falls_back_to_email_when_user_id_missing(self):
+        assert (
+            _user_owns_batch(
+                _batch(created_by_user_id=None),
+                _user(user_id=None),
+            )
+            is True
+        )
+
+    def test_email_mismatch_rejects(self):
+        assert (
+            _user_owns_batch(
+                _batch(created_by_email="someone@else.com", created_by_user_id=None),
+                _user(user_id=None),
+            )
+            is False
+        )
+
+    def test_empty_email_does_not_grant_access(self):
+        # Both sides empty must not collide into "owner".
+        assert (
+            _user_owns_batch(
+                _batch(created_by_email="", created_by_user_id=None),
+                _user(email="", user_id=None),
+            )
+            is False
+        )
+
+
+class TestGetBatchAuthz:
+    """Authorization branches on GET /api/v1/batch/{batch_id}."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_read_batch(self):
+        batch = _batch()
+        with patch(
+            "rag_processor.api.batch.get_batch_status",
+            return_value=(batch, []),
+        ):
+            resp = await get_batch(batch.batch_id, user=_user())
+        assert resp.batch_id == batch.batch_id
+
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_404_not_403(self):
+        batch = _batch(created_by_user_id="other-user", created_by_email="other@x")
+        with (
+            patch(
+                "rag_processor.api.batch.get_batch_status",
+                return_value=(batch, []),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await get_batch(batch.batch_id, user=_user())
+        # 404 not 403 — must not leak existence.
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_missing_batch_returns_404(self):
+        with (
+            patch(
+                "rag_processor.api.batch.get_batch_status",
+                return_value=(None, []),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await get_batch(uuid4(), user=_user())
+        assert exc.value.status_code == 404
+
+
+class TestGetJobAuthz:
+    """Authorization branches on GET /api/v1/batch/job/{job_id}."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_read_job(self):
+        batch = _batch()
+        job = _job(batch.batch_id)
+        with (
+            patch("rag_processor.api.batch.get_job_status", return_value=job),
+            patch(
+                "rag_processor.api.batch.get_batch_status",
+                return_value=(batch, [job]),
+            ),
+        ):
+            resp = await get_job(job.job_id, user=_user())
+        assert resp.job_id == job.job_id
+
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_404(self):
+        batch = _batch(created_by_user_id="other-user", created_by_email="other@x")
+        job = _job(batch.batch_id)
+        with (
+            patch("rag_processor.api.batch.get_job_status", return_value=job),
+            patch(
+                "rag_processor.api.batch.get_batch_status",
+                return_value=(batch, [job]),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await get_job(job.job_id, user=_user())
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_missing_job_returns_404(self):
+        with (
+            patch("rag_processor.api.batch.get_job_status", return_value=None),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await get_job(uuid4(), user=_user())
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_orphaned_job_with_missing_batch_returns_404(self):
+        # Defensive: a job whose batch row has been deleted must not be readable.
+        job = _job(uuid4())
+        with (
+            patch("rag_processor.api.batch.get_job_status", return_value=job),
+            patch(
+                "rag_processor.api.batch.get_batch_status",
+                return_value=(None, []),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await get_job(job.job_id, user=_user())
+        assert exc.value.status_code == 404

--- a/tests/unit/test_batch_authz.py
+++ b/tests/unit/test_batch_authz.py
@@ -16,7 +16,8 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
-from rag_processor.api.batch import _user_owns_batch, get_batch, get_job
+from rag_processor.api.batch import get_batch, get_job
+from rag_processor.auth.dependencies import batch_is_owned_by
 from rag_processor.auth.models import CloudflareUser
 from rag_processor.models.batch import Batch, BatchStatus
 from rag_processor.models.job import (
@@ -68,30 +69,28 @@ def _job(batch_id) -> Job:
     )
 
 
-class TestUserOwnsBatch:
+def _owns(batch, user) -> bool:
+    """Thin wrapper so tests read like the previous _user_owns_batch(batch, user)."""
+    return batch_is_owned_by(
+        batch, requester_user_id=user.user_id, requester_email=user.email
+    )
+
+
+class TestBatchIsOwnedBy:
     """Direct tests for the ownership helper."""
 
     def test_matches_on_user_id(self):
-        assert _user_owns_batch(_batch(), _user()) is True
+        assert _owns(_batch(), _user()) is True
 
     def test_user_id_mismatch_rejects(self):
-        assert (
-            _user_owns_batch(_batch(created_by_user_id="someone-else"), _user())
-            is False
-        )
+        assert _owns(_batch(created_by_user_id="someone-else"), _user()) is False
 
     def test_falls_back_to_email_when_user_id_missing(self):
-        assert (
-            _user_owns_batch(
-                _batch(created_by_user_id=None),
-                _user(user_id=None),
-            )
-            is True
-        )
+        assert _owns(_batch(created_by_user_id=None), _user(user_id=None)) is True
 
     def test_email_mismatch_rejects(self):
         assert (
-            _user_owns_batch(
+            _owns(
                 _batch(created_by_email="someone@else.com", created_by_user_id=None),
                 _user(user_id=None),
             )
@@ -101,9 +100,24 @@ class TestUserOwnsBatch:
     def test_empty_email_does_not_grant_access(self):
         # Both sides empty must not collide into "owner".
         assert (
-            _user_owns_batch(
+            _owns(
                 _batch(created_by_email="", created_by_user_id=None),
                 _user(email="", user_id=None),
+            )
+            is False
+        )
+
+    def test_user_id_mismatch_does_not_fall_back_to_email(self):
+        # Regression: when both user_ids are present and differ, a
+        # coincidentally-matching email must NOT grant access. (CodeRabbit
+        # PR #26 review.)
+        assert (
+            _owns(
+                _batch(
+                    created_by_user_id="u-owner",
+                    created_by_email="match@example.com",
+                ),
+                _user(user_id="u-intruder", email="match@example.com"),
             )
             is False
         )

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -483,7 +483,10 @@ class TestWebSocketRouter:
             result = await verify_ws_token(None)
 
         assert result is not None
-        assert result["email"] == "anonymous@local"
+        # Bypass identity must match CloudflareAuthMiddleware._get_bypass_user
+        # so ownership checks work across HTTP and WebSocket. See PR #26 review.
+        assert result["email"] == "dev@localhost"
+        assert result["user_id"] == "dev-user-001"
 
     @pytest.mark.asyncio
     async def test_verify_ws_token_no_token_with_auth(self) -> None:

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -265,6 +265,47 @@ class TestWebSocketEndpoint:
             code=status.WS_1008_POLICY_VIOLATION
         )
 
+    @pytest.mark.asyncio
+    async def test_websocket_rejects_non_owner(self, mock_ws_logger: MagicMock) -> None:
+        """Caller authenticated as user A cannot subscribe to user B's batch."""
+        from fastapi import WebSocket, status
+
+        batch_id = uuid4()
+        mock_websocket = AsyncMock(spec=WebSocket)
+
+        mock_verify = AsyncMock(
+            return_value={"email": "intruder@example.com", "user_id": "u-intruder"}
+        )
+
+        # Batch belongs to a different user.
+        mock_batch = MagicMock()
+        mock_batch.created_by_user_id = "u-owner"
+        mock_batch.created_by_email = "owner@example.com"
+        mock_batch_status = MagicMock(return_value=(mock_batch, []))
+
+        mock_cm = MagicMock()
+        mock_cm.connect = AsyncMock()
+        mock_cm.send_personal = AsyncMock()
+        mock_cm.disconnect = MagicMock()
+
+        with (
+            patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
+            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch("rag_processor.websocket.router.connection_manager", mock_cm),
+        ):
+            from rag_processor.websocket.router import websocket_batch_status
+
+            await websocket_batch_status(
+                mock_websocket, batch_id, cf_access_token="valid-token"
+            )
+
+        # Closes with the same code as "not found" so existence is not leaked.
+        mock_websocket.close.assert_called_once_with(
+            code=status.WS_1008_POLICY_VIOLATION
+        )
+        # Never accepted the connection.
+        mock_cm.connect.assert_not_called()
+
     @pytest.mark.skip(
         reason="Module-level Redis import happens before patches can be applied"
     )

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -306,6 +306,53 @@ class TestWebSocketEndpoint:
         # Never accepted the connection.
         mock_cm.connect.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_websocket_rejects_matching_email_with_different_user_id(
+        self, mock_ws_logger: MagicMock
+    ) -> None:
+        """Regression: matching email + different user_id must NOT grant access.
+
+        The previous WebSocket ownership check OR'd id-match and email-match,
+        so a token whose email happened to match the batch owner's email
+        would bypass the user_id check. user_id must take precedence when
+        both sides have it. (CodeRabbit PR #26 review.)
+        """
+        from fastapi import WebSocket, status
+
+        batch_id = uuid4()
+        mock_websocket = AsyncMock(spec=WebSocket)
+
+        # Same email as the batch owner, different user_id.
+        mock_verify = AsyncMock(
+            return_value={"email": "owner@example.com", "user_id": "u-intruder"}
+        )
+
+        mock_batch = MagicMock()
+        mock_batch.created_by_user_id = "u-owner"
+        mock_batch.created_by_email = "owner@example.com"
+        mock_batch_status = MagicMock(return_value=(mock_batch, []))
+
+        mock_cm = MagicMock()
+        mock_cm.connect = AsyncMock()
+        mock_cm.send_personal = AsyncMock()
+        mock_cm.disconnect = MagicMock()
+
+        with (
+            patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
+            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch("rag_processor.websocket.router.connection_manager", mock_cm),
+        ):
+            from rag_processor.websocket.router import websocket_batch_status
+
+            await websocket_batch_status(
+                mock_websocket, batch_id, cf_access_token="valid-token"
+            )
+
+        mock_websocket.close.assert_called_once_with(
+            code=status.WS_1008_POLICY_VIOLATION
+        )
+        mock_cm.connect.assert_not_called()
+
     @pytest.mark.skip(
         reason="Module-level Redis import happens before patches can be applied"
     )

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -23,7 +23,12 @@ class TestVerifyWsToken:
 
     @pytest.mark.asyncio
     async def test_verify_ws_token_auth_disabled(self) -> None:
-        """Test token verification when auth is disabled."""
+        """Bypass identity must match CloudflareAuthMiddleware._get_bypass_user.
+
+        Regression for PR #26 review: a mismatch (anonymous@local vs
+        dev@localhost) broke ownership checks for batches created over HTTP
+        in dev mode.
+        """
         mock_settings = MagicMock()
         mock_settings.cloudflare_enabled = False
 
@@ -33,8 +38,37 @@ class TestVerifyWsToken:
             result = await verify_ws_token(None)
 
         assert result is not None
-        assert result["email"] == "anonymous@local"
-        assert result["user_id"] == "local"
+        assert result["email"] == "dev@localhost"
+        assert result["user_id"] == "dev-user-001"
+
+    @pytest.mark.asyncio
+    async def test_verify_ws_token_swallows_network_errors(self) -> None:
+        """Non-JWT errors from verify_cloudflare_token must close cleanly.
+
+        Regression for PR #26 review: httpx.ConnectError / TimeoutException /
+        HTTPStatusError and json.JSONDecodeError aren't jwt.* subclasses and
+        previously propagated, closing the socket with 1011 (internal error)
+        instead of 1008 (policy violation). Mirror the HTTP middleware's
+        broad except.
+        """
+        import httpx
+
+        mock_settings = MagicMock()
+        mock_settings.cloudflare_enabled = True
+
+        mock_verify = AsyncMock(side_effect=httpx.ConnectError("JWKS unreachable"))
+
+        with (
+            patch("rag_processor.websocket.router.settings", mock_settings),
+            patch(
+                "rag_processor.websocket.router.verify_cloudflare_token", mock_verify
+            ),
+        ):
+            from rag_processor.websocket.router import verify_ws_token
+
+            result = await verify_ws_token("opaque-token")
+
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_verify_ws_token_no_token_with_auth_enabled(self) -> None:

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -300,7 +300,11 @@ class TestWebSocketEndpoint:
             return_value={"email": "user@example.com", "user_id": "user-123"}
         )
 
+        # Batch must be owned by the authenticated user; otherwise the WS
+        # endpoint closes the connection without replaying events.
         mock_batch = MagicMock()
+        mock_batch.created_by_user_id = "user-123"
+        mock_batch.created_by_email = "user@example.com"
         mock_batch_status = MagicMock(return_value=(mock_batch, []))
 
         mock_cm = MagicMock()


### PR DESCRIPTION
## Summary

Security review of the frontend, FastAPI backend, and GitHub Actions workflows.
Full findings (with severities, file:line refs, and follow-ups not in this PR)
are in [`SECURITY-FINDINGS.md`](./SECURITY-FINDINGS.md).

## What this PR fixes

| # | File | Severity | Change |
|---|------|----------|--------|
| 1 | `src/rag_processor/api/batch.py` | **CRITICAL** | `GET /batch/{batch_id}` and `GET /batch/job/{job_id}` had auth but no ownership check — any authenticated user could read any other user's batch (OWASP A01 / BOLA). Now require `Depends(get_current_user)` and call `auth/dependencies.py::batch_is_owned_by`, which enforces user_id-takes-precedence (matching email cannot override a mismatched user_id). Non-owners get 404 so batch existence isn't leaked. Unauthorized-access warnings log opaque IDs only — no PII. |
| 2 | `src/rag_processor/websocket/router.py` | **CRITICAL** | Same `batch_is_owned_by` check on the `/ws/batch/{batch_id}` upgrade so the WS authz path can't diverge from REST. Plus: bypass-mode identity now matches `CloudflareAuthMiddleware._get_bypass_user()` (`dev@localhost` / `dev-user-001`) so batches created over HTTP in dev are still readable on WS; JWKS network errors (httpx + `json.JSONDecodeError`) are caught so the socket closes with 1008 (policy violation) instead of 1011 (internal error); success-path log redacted to opaque IDs. |
| 3 | `src/rag_processor/core/config.py` + `.env.example` | **HIGH** | `cors_allowed_origins` setting, **empty by default** so production fails closed; overridable via `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS`. Dev value documented in `.env.example`. Resolves SonarCloud python:S5332 on the previous hardcoded `http://localhost:*` defaults. |
| 4 | `src/rag_processor/main.py` | **HIGH** | Read CORS origins from settings; **refuse to start** if `"*"` appears with credentials; replaced `allow_methods=["*"]` / `allow_headers=["*"]` with explicit method/header lists. |
| 5 | `src/rag_processor/auth/cloudflare.py` + `websocket/router.py` | **HIGH** | Bypass mode (`cloudflare_enabled=false`) silently authenticated every request as a fixed dev user with the `developers` group. Now logs `CRITICAL` on every HTTP request AND on every WebSocket upgrade while active so a misconfigured prod deploy is loud. |
| 6 | `.github/workflows/sonarcloud.yml` *(mooted by main)* | HIGH | The initial commit pinned `sonarsource/sonarqube-quality-gate-action@master` → SHA `cf038b0e…` (v1.2.0) and added `harden-runner`. **After this PR was opened, main merged #27 (`4055d57`) which replaced this file with a call to an org-level reusable workflow.** The merge will resolve in favor of main, so the SHA-pin lands via the org workflow rather than this PR's diff. Audit-trail-wise the pin still happened, just via a different commit. |
| 7 | `.github/workflows/dependency-review.yml` | **MEDIUM** | Pinned `actions/dependency-review-action@v4` → SHA `2031cfc0…` (v4.9.0). Added `harden-runner`. |
| 8 | `.github/workflows/{ci,python-compatibility,security-analysis,performance-regression}.yml` | CI hardening | After the org workflow update added a `no-build` input (default `true`) that broke hatchling-based projects, set `no-build: false` on every caller so editable installs work again. |

## What the review verified safe (no change needed)

- **No unsafe HTML rendering**: zero hits for `dangerouslySetInnerHTML`,
  `innerHTML`, or `eval(` in `frontend/src/`. All backend strings flow through
  JSX, which auto-escapes.
- **No hardcoded API keys/URLs**: all URLs come from `import.meta.env.VITE_*`.
- **File upload**: libmagic content-based MIME validation, size cap,
  filename sanitization (`Path(filename).name` + regex), batch directory uses
  a server-generated UUID — no path traversal on write.
- **No file-content GET endpoint**: nothing to traverse on read.
- **A03 injection**: no SQL anywhere (Redis only, no `EVAL`/Lua), and no LLM
  prompt construction in this service (gateway-only — downstream consumers
  need their own prompt-injection review).

## Follow-ups (documented, not in this PR)

See "Follow-ups" section of `SECURITY-FINDINGS.md`. Highlights:
- §1.3 Move WebSocket auth token off the URL query string.
- §1.4 Remove unused `localStorage` Bearer-token interceptor in `useApi.ts`.
- §2.3 Require an explicit second flag (`RAG_PROCESSOR_ALLOW_AUTH_BYPASS=1`)
  before honoring `cloudflare_enabled=false`.
- §2.5 Stream-read uploads instead of buffering the whole body before the
  size check.
- §2.6 Drop Python version from public `/health/live` responses.
- §4.5 SHA-pin org-owned reusable workflow callouts.
- Tighten `batch_is_owned_by` to drop the email fallback once all batches
  have `created_by_user_id`.

## Test plan

- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run pytest tests/` — 334 passed, 1 skipped (pre-existing module-level
      Redis import skip).
- [x] SonarCloud Quality Gate — passed (0 issues, 0 hotspots, 93.5% new-code
      coverage, 0% duplication).
- [ ] Manual: confirm `RAG_PROCESSOR_CORS_ALLOWED_ORIGINS=["*"]` causes
      startup to abort.
- [ ] Manual: confirm a second authenticated user cannot read another user's
      batch (`GET /api/v1/batch/{other_users_batch_id}` → 404) and cannot
      subscribe to it over WebSocket.

## Known CI failures

- **Python Compatibility / Test (Python 3.10)** — pre-existing: ten files in
  `src/` use `from datetime import UTC` (Python 3.11+ stdlib). My PR didn't
  introduce this; fixing it is a codebase-wide migration.
- **Security Analysis / Python Security Scan** — pre-existing: `pip-audit`
  flags the 15 dependency CVEs GitHub keeps surfacing on push. Needs a
  separate dependency-bump branch.
