### PR TITLE
docs: enrich route OpenAPI metadata + fix(ci): install dev extras for compat matrix

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -53,6 +53,9 @@ jobs:
       include-macos: false  # Disabled: python-magic requires libmagic (see note above)
       include-windows: false  # Disabled: python-magic requires libmagic DLL (see note above)
       source-directory: 'src'
+      # pyproject.toml's addopts includes --cov=src/rag_processor, so we need
+      # the dev extras (pytest-cov) installed for pytest to start.
+      extra-dependencies: 'dev'
       # Drop -m marker filter: the org reusable expands $TEST_COMMAND unquoted
       # via bash, which word-splits `-m "not slow and not integration"` into
       # broken tokens (pytest sees `slow` as a positional path arg). The

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -89,8 +89,13 @@ class BatchDetailResponse(BaseModel):
 @router.get(
     "/{batch_id}",
     response_model=BatchDetailResponse,
+    status_code=status.HTTP_200_OK,
     summary="Get batch status",
-    description="Get the status and details of a batch and its jobs.",
+    description=(
+        "Get the status and details of a batch including all of its jobs, "
+        "file metadata, and timestamps. Requires Cloudflare Access "
+        "authentication."
+    ),
     responses={
         404: {"description": "Batch not found"},
     },
@@ -98,14 +103,20 @@ class BatchDetailResponse(BaseModel):
 async def get_batch(batch_id: UUID) -> BatchDetailResponse:
     """Get batch status and job list.
 
+    Returns the current status of a batch and a detail record for every
+    job that belongs to it, including classification, pipeline, retry
+    count, and timestamps.
+
+    Authentication: Requires a valid Cloudflare Access JWT.
+
     Args:
-        batch_id: Batch identifier.
+        batch_id: Batch identifier (UUID).
 
     Returns:
-        BatchDetailResponse with batch and job details.
+        BatchDetailResponse with batch metadata and the list of jobs.
 
     Raises:
-        HTTPException: If batch not found.
+        HTTPException: 404 if no batch with the given ID exists.
     """
     batch, jobs = get_batch_status(batch_id)
 
@@ -151,8 +162,13 @@ async def get_batch(batch_id: UUID) -> BatchDetailResponse:
 @router.get(
     "/job/{job_id}",
     response_model=JobDetailResponse,
+    status_code=status.HTTP_200_OK,
     summary="Get job status",
-    description="Get the status and details of a specific job.",
+    description=(
+        "Get the status and details of a specific job, including pipeline "
+        "routing, error message, retry count, and timestamps. Requires "
+        "Cloudflare Access authentication."
+    ),
     responses={
         404: {"description": "Job not found"},
     },
@@ -160,14 +176,20 @@ async def get_batch(batch_id: UUID) -> BatchDetailResponse:
 async def get_job(job_id: UUID) -> JobDetailResponse:
     """Get job status and details.
 
+    Returns the current state of a single processing job, including the
+    target pipeline, file metadata, retry information, and lifecycle
+    timestamps.
+
+    Authentication: Requires a valid Cloudflare Access JWT.
+
     Args:
-        job_id: Job identifier.
+        job_id: Job identifier (UUID).
 
     Returns:
-        JobDetailResponse with job details.
+        JobDetailResponse with job metadata and processing state.
 
     Raises:
-        HTTPException: If job not found.
+        HTTPException: 404 if no job with the given ID exists.
     """
     job = get_job_status(job_id)
 

--- a/src/rag_processor/api/health.py
+++ b/src/rag_processor/api/health.py
@@ -58,18 +58,24 @@ class ReadinessStatus(HealthStatus):
     response_model=HealthStatus,
     status_code=status.HTTP_200_OK,
     summary="Liveness probe",
-    description="Indicates if the application is running. Used by Kubernetes liveness probe.",
+    description=(
+        "Indicates whether the application process is alive. Intended for "
+        "Kubernetes liveness probes. This endpoint is public and does not "
+        "require authentication."
+    ),
 )
 async def liveness() -> HealthStatus:
     """Kubernetes liveness probe.
 
-    Returns HTTP 200 if the application is alive.
-    If this fails, Kubernetes will restart the pod.
+    Returns HTTP 200 whenever the process is responsive. Performs no
+    dependency checks, so it should not fail due to transient downstream
+    issues. If this fails, Kubernetes will restart the pod.
 
-    This should be a simple, fast check that doesn't depend on external services.
+    Authentication: Public endpoint, no authentication required.
 
     Returns:
-        HealthStatus with status and uptime.
+        HealthStatus with current `status`, `uptime_seconds`, and
+        runtime version metadata.
     """
     return HealthStatus(
         status="ok",
@@ -168,29 +174,35 @@ async def check_external_service() -> ReadinessCheck:
 @router.get(
     "/ready",
     response_model=ReadinessStatus,
+    status_code=status.HTTP_200_OK,
     responses={
         200: {"description": "Application is ready to serve traffic"},
         503: {"description": "Application is not ready (dependencies unavailable)"},
     },
     summary="Readiness probe",
-    description="Checks if the application can serve traffic. Used by Kubernetes readiness probe.",
+    description=(
+        "Checks whether the application can serve traffic by exercising "
+        "all critical dependencies (database, cache, external services). "
+        "Intended for Kubernetes readiness probes. This endpoint is "
+        "public and does not require authentication."
+    ),
 )
 async def readiness() -> ReadinessStatus:
     """Kubernetes readiness probe.
 
-    Checks all critical dependencies:
-    - Database connectivity
-    - Cache availability (if configured)
-    - External service health (if applicable)
+    Runs the configured dependency health checks (database, cache, and
+    optional external services) and aggregates their results. Returns
+    HTTP 503 if any critical dependency is unavailable; if this fails,
+    Kubernetes will stop routing traffic to this pod.
 
-    Returns HTTP 503 if any critical dependency is unavailable.
-    If this fails, Kubernetes will stop sending traffic to this pod.
+    Authentication: Public endpoint, no authentication required.
 
     Returns:
-        ReadinessStatus with overall health and individual dependency checks.
+        ReadinessStatus with overall health and per-dependency check
+        results (latency and error details).
 
     Raises:
-        HTTPException: When the application is not ready (503 status).
+        HTTPException: 503 when one or more critical dependencies fail.
     """
     checks: dict[str, ReadinessCheck] = {}
 
@@ -230,18 +242,24 @@ async def readiness() -> ReadinessStatus:
     response_model=HealthStatus,
     status_code=status.HTTP_200_OK,
     summary="Startup probe",
-    description="Indicates if the application has completed startup. Used by Kubernetes startup probe.",
+    description=(
+        "Indicates whether the application has completed startup. Intended "
+        "for Kubernetes startup probes that delay liveness and readiness "
+        "checks during slow initialization. This endpoint is public and "
+        "does not require authentication."
+    ),
 )
 async def startup() -> HealthStatus:
     """Kubernetes startup probe.
 
-    Used during application startup to delay liveness and readiness checks.
-    This prevents the application from being killed during slow initialization.
+    Returns HTTP 200 once the application has finished initializing.
+    Kubernetes uses this to defer liveness and readiness checks during
+    boot so that slow startups don't trigger restarts.
 
-    Returns HTTP 200 once the application has fully started.
+    Authentication: Public endpoint, no authentication required.
 
     Returns:
-        HealthStatus indicating startup completion.
+        HealthStatus indicating startup completion and uptime.
     """
     # Add any startup checks here (e.g., database migrations completed)
     # For most applications, being alive means startup is complete
@@ -257,14 +275,20 @@ async def startup() -> HealthStatus:
     response_model=HealthStatus,
     status_code=status.HTTP_200_OK,
     summary="Basic health check",
-    description="Simple health check endpoint for load balancers and monitoring.",
+    description=(
+        "Compatibility alias for `/health/live`. Provided for load "
+        "balancers and monitors that expect a `/health` endpoint. "
+        "Public endpoint, no authentication required."
+    ),
     include_in_schema=False,  # Hide from OpenAPI docs (use /live instead)
 )
 async def health() -> HealthStatus:
     """Basic health check endpoint.
 
-    Alias for /health/live for compatibility with load balancers
-    that expect a /health endpoint.
+    Compatibility alias for `/health/live`, intended for load balancers
+    and monitoring systems that expect a `/health` path.
+
+    Authentication: Public endpoint, no authentication required.
 
     Returns:
         HealthStatus from the liveness check.

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -190,10 +190,15 @@ async def validate_file(
     response_model=IngestResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Upload files for processing",
-    description="Upload one or more files for RAG pipeline processing.",
+    description=(
+        "Upload one or more files for RAG pipeline processing. Each file is "
+        "validated for size and MIME type, sanitized, then assigned to a "
+        "pipeline. Requires Cloudflare Access authentication."
+    ),
     responses={
         400: {"description": "Invalid file(s) provided"},
         413: {"description": "File(s) too large"},
+        422: {"description": "Validation error"},
     },
 )
 async def ingest_files(
@@ -214,19 +219,26 @@ async def ingest_files(
     """Upload files for RAG pipeline processing.
 
     Accepts multiple files via multipart/form-data. Each file is validated
-    for size and type, then saved to the upload directory.
+    for size and type, sanitized, then saved to the upload directory and
+    routed to the appropriate processing pipeline. A new batch is created
+    grouping the uploaded files together.
+
+    Authentication: Requires a valid Cloudflare Access JWT.
 
     Args:
-        files: List of files to upload.
+        files: List of files to upload (multipart/form-data).
         priority: Processing priority (high, normal, low).
-        target_vector_store: Optional target vector store.
+        target_vector_store: Optional target vector store identifier.
         user: Authenticated user from Cloudflare Access.
 
     Returns:
-        IngestResponse with batch and job information.
+        IngestResponse containing the new batch ID, batch status, total
+        accepted files, per-job metadata, and a human-readable message.
 
     Raises:
-        HTTPException: If no valid files provided or validation fails.
+        HTTPException: 400 if no files or all files fail validation;
+            413 if a file exceeds the configured size limit; 422 if
+            request validation fails.
     """
     if not files:
         raise HTTPException(
@@ -355,17 +367,31 @@ async def ingest_files(
 
 @router.get(
     "/health",
+    status_code=status.HTTP_200_OK,
     summary="Check ingest endpoint health",
-    description="Verify that the ingest endpoint is ready to accept uploads.",
+    description=(
+        "Verify the ingest endpoint can accept uploads by checking that the "
+        "upload directory is writable. Requires Cloudflare Access "
+        "authentication. Returns 503 if the upload directory is unavailable."
+    ),
+    responses={
+        503: {"description": "Upload directory not writable"},
+    },
 )
 async def ingest_health() -> dict[str, str]:
     """Check ingest endpoint health.
 
+    Verifies the upload directory exists and is writable by creating
+    and removing a probe file. Used to confirm the ingest service is
+    able to accept new uploads.
+
+    Authentication: Requires a valid Cloudflare Access JWT.
+
     Returns:
-        Health status dictionary.
+        Dictionary with `status` ("healthy") and `upload_dir` path.
 
     Raises:
-        HTTPException: If upload directory is not writable.
+        HTTPException: 503 if the upload directory is not writable.
     """
     # Check upload directory is writable
     upload_dir = Path(settings.upload_dir)

--- a/src/rag_processor/api/user.py
+++ b/src/rag_processor/api/user.py
@@ -28,19 +28,30 @@ class UserResponse(BaseModel):
 @router.get(
     "/me",
     response_model=UserResponse,
+    status_code=200,
     summary="Get current user",
-    description="Returns the currently authenticated user's information.",
+    description=(
+        "Returns the currently authenticated user's identity information "
+        "(email, user ID, and group memberships) extracted from the "
+        "Cloudflare Access JWT. Requires Cloudflare Access authentication."
+    ),
 )
 async def get_me(
     user: CloudflareUser = Depends(get_current_user),
 ) -> UserResponse:
     """Get current authenticated user information.
 
+    Reads the verified Cloudflare Access user attached to the request
+    by the auth middleware and returns the subset of fields safe to
+    expose to the frontend.
+
+    Authentication: Requires a valid Cloudflare Access JWT.
+
     Args:
-        user: The authenticated user from Cloudflare Access.
+        user: The authenticated user from Cloudflare Access (injected).
 
     Returns:
-        User information including email and groups.
+        UserResponse with `email`, optional `user_id`, and `groups`.
     """
     return UserResponse(
         email=user.email,

--- a/src/rag_processor/api/user.py
+++ b/src/rag_processor/api/user.py
@@ -5,7 +5,7 @@ Provides endpoints for accessing current user information.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 
 from rag_processor.auth.dependencies import get_current_user
@@ -28,7 +28,7 @@ class UserResponse(BaseModel):
 @router.get(
     "/me",
     response_model=UserResponse,
-    status_code=200,
+    status_code=status.HTTP_200_OK,
     summary="Get current user",
     description=(
         "Returns the currently authenticated user's identity information "

--- a/src/rag_processor/core/cache.py
+++ b/src/rag_processor/core/cache.py
@@ -91,7 +91,13 @@ async def get_redis() -> Redis:
 async def close_redis() -> None:
     """Close Redis connection pool.
 
-    Call this on application shutdown.
+    Closes the global Redis connection pool and resets it to None so
+    the next call to `get_redis()` will create a fresh pool. Safe to
+    call when no pool has been initialized. Intended for invocation
+    from an application shutdown handler.
+
+    Returns:
+        None.
     """
     global _redis_pool
 

--- a/src/rag_processor/main.py
+++ b/src/rag_processor/main.py
@@ -117,12 +117,27 @@ app.include_router(batch_router, prefix="/api/v1")
 app.include_router(websocket_router)
 
 
-@app.get("/", tags=["root"])
+@app.get(
+    "/",
+    tags=["root"],
+    summary="API information",
+    description=(
+        "Returns basic API metadata including the service name, version, "
+        "and the path to the interactive OpenAPI docs. Requires Cloudflare "
+        "Access authentication when `CLOUDFLARE_ENABLED=true`."
+    ),
+)
 async def root() -> dict[str, str]:
-    """Root endpoint returning API information.
+    """API information.
+
+    Returns metadata about the running gateway: service name, version,
+    and the URL of the interactive OpenAPI documentation.
+
+    Authentication: Requires a valid Cloudflare Access JWT in the
+    `Cf-Access-Jwt-Assertion` header when Cloudflare auth is enabled.
 
     Returns:
-        Dictionary with API name and version.
+        Dictionary with `name`, `version`, and `docs` URL.
     """
     return {
         "name": "RAG Processor Gateway",

--- a/src/rag_processor/models/batch.py
+++ b/src/rag_processor/models/batch.py
@@ -90,7 +90,14 @@ class Batch(BaseModel):
     def update_status(self) -> None:
         """Update batch status based on job counts.
 
-        Calculates the appropriate status based on completed and failed counts.
+        Recomputes `status` from `completed_files` and `failed_files`
+        relative to `total_files`, and refreshes `updated_at`. The
+        status transitions to PROCESSING while jobs remain, COMPLETED
+        when all succeed, FAILED when all fail, and PARTIAL when the
+        outcome is mixed.
+
+        Returns:
+            None. Mutates `self.status` and `self.updated_at` in place.
         """
         self.updated_at = datetime.now(tz=UTC)
 

--- a/src/rag_processor/models/job.py
+++ b/src/rag_processor/models/job.py
@@ -158,13 +158,27 @@ class Job(BaseModel):
     )
 
     def mark_processing(self) -> None:
-        """Mark job as processing."""
+        """Mark job as processing.
+
+        Sets `status` to PROCESSING and stamps `started_at` and
+        `updated_at` with the current UTC time.
+
+        Returns:
+            None. Mutates `status`, `started_at`, `updated_at` in place.
+        """
         self.status = JobStatus.PROCESSING
         self.started_at = datetime.now(tz=UTC)
         self.updated_at = self.started_at
 
     def mark_completed(self) -> None:
-        """Mark job as completed."""
+        """Mark job as completed.
+
+        Sets `status` to COMPLETED and stamps `completed_at` and
+        `updated_at` with the current UTC time.
+
+        Returns:
+            None. Mutates `status`, `completed_at`, `updated_at` in place.
+        """
         self.status = JobStatus.COMPLETED
         self.completed_at = datetime.now(tz=UTC)
         self.updated_at = self.completed_at


### PR DESCRIPTION
## Summary

Two related changes, rebased onto `main` to incorporate the workflow SHA pin from PR #27:

1. **`docs:`** — enrich every HTTP route handler so that FastAPI's `/docs` (Swagger UI) and `/redoc` render an actionable summary, description, response model, status code, tag grouping, and explicit error responses. Also fills in small docstring gaps in non-route service/model code (Returns sections on void mutators, expanded `close_redis` docstring).
2. **`fix(ci):`** — install the `dev` extras when running the Python Compatibility Matrix workflow, so `pytest-cov` is available and pytest doesn't exit with code 4 (cmdline usage error) on the `--cov=src/rag_processor` flag inherited from `pyproject.toml`.

The earlier `ci: pin org reusable workflows to known-good SHA` commit has been **dropped** during rebase — it's obsolete now that PR #27 has merged the newer good pin (`1b2d33c47cc11a96b9757b49f41873c54e75f57c`) directly to `main`.

**No business logic was changed.** All 318 existing tests pass; `ruff check`, `ruff format --check` clean; SonarCloud Quality Gate passed (0 new issues, 100% coverage on new code).

## OpenAPI route enrichment — every route covered

| Method | Path | Tags | Status | Changes |
|---|---|---|---|---|
| `GET` | `/` | `root` | `200` | Added `summary` + `description`; rewrote docstring to document auth + return shape |
| `GET` | `/health/live` | `health` | `200` | Expanded `description` to flag public/no-auth; rewrote docstring |
| `GET` | `/health/ready` | `health` | `200`, `503` | Added explicit `status_code=status.HTTP_200_OK`; expanded `description`/docstring; documented no-auth |
| `GET` | `/health/startup` | `health` | `200` | Expanded `description`/docstring; documented no-auth |
| `GET` | `/health/` | `health` | `200` | Expanded `description`/docstring; documented no-auth (hidden from schema by design) |
| `GET` | `/api/v1/user/me` | `user` | `200` | Added explicit `status_code=status.HTTP_200_OK`; expanded `description`/docstring; documented Cloudflare Access requirement |
| `POST` | `/api/v1/ingest` | `ingest` | `201`, `400`, `413`, **`422`** | **Added `responses[422]` (request body endpoint)**; expanded `description`/docstring; documented auth and full error semantics |
| `GET` | `/api/v1/ingest/health` | `ingest` | `200`, `503` | Added explicit `status_code=status.HTTP_200_OK` and `responses[503]`; expanded `description`/docstring; documented auth |
| `GET` | `/api/v1/batch/{batch_id}` | `batch` | `200`, `404` | Added explicit `status_code=status.HTTP_200_OK`; expanded `description`/docstring; documented auth |
| `GET` | `/api/v1/batch/job/{job_id}` | `batch` | `200`, `404` | Added explicit `status_code=status.HTTP_200_OK`; expanded `description`/docstring; documented auth |
| `WS` | `/ws/batch/{batch_id}` | `websocket` | n/a | Untouched — WebSocket routes are outside the OpenAPI HTTP-method scope; existing docstring already documents auth + behavior |

### `/docs` confirmation

After these changes, FastAPI's `/docs` endpoint renders **all 9 visible HTTP routes with summaries** (verified by inspecting `app.openapi()`).

`GET /health/` is intentionally `include_in_schema=False` (alias of `/health/live`) and so does not appear in `/docs` by design.

### Authentication accuracy

Verified against `auth/cloudflare.py`: the `CloudflareAuthMiddleware` is applied globally in `main.py` and exempts only `PUBLIC_PATHS = {/health, /health/, /health/live, /health/ready, /health/startup, /metrics, /docs, /openapi.json, /redoc}` plus the `path.startswith("/health")` prefix. The "Requires Cloudflare Access authentication" note in the docstrings for `/`, `/api/v1/user/me`, `/api/v1/ingest`, `/api/v1/ingest/health`, `/api/v1/batch/*`, and `/api/v1/batch/job/*` correctly reflects what the middleware enforces.

## Service / model docstring polish

- `Batch.update_status` — added `Returns: None` and described the state transition.
- `Job.mark_processing` / `Job.mark_completed` — added `Returns: None` and described the fields mutated.
- `core/cache.py::close_redis` — expanded the docstring with explicit `Returns:` and noted re-initialization safety.

## `fix(ci):` details

The Python Compatibility Matrix workflow's test command runs `pytest`, which reads `addopts = ["-ra", "--strict-markers", "--strict-config", "--cov=src/rag_processor", ...]` from `pyproject.toml`. Without the `dev` extras installed (which provide `pytest-cov`), pytest exits with code 4 ("command-line usage error") before collecting any tests — matching the consistent ~26s failure observed across all matrix Python versions when this workflow first ran on a non-trivial PR. Passing `extra-dependencies: 'dev'` matches the pattern already in use by `performance-regression.yml`.

## Test plan

- [x] `uv run pytest tests/ --no-cov -q` — 299 passed (+ 19 integration, 1 skipped)
- [x] `uv run ruff check src/` — All checks passed
- [x] `uv run ruff format --check src/` — clean
- [x] `python -c "from rag_processor.main import app; app.openapi()"` — OpenAPI spec generates without error
- [x] Verified every visible route has a non-empty `summary` and at least one tag
- [x] SonarCloud: Quality Gate passed, 0 new issues, 100% coverage on new code
- [x] No business logic touched — only docstrings, route decorator metadata, one workflow input

## Commit history (after rebase)

```
7873390 fix(ci): install dev extras for Python Compatibility Matrix
6b8309d docs: enrich route OpenAPI metadata and tighten docstrings
4055d57 (origin/main) fix(ci): migrate sonarcloud to org workflow and pin @main to SHA (#27)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced API endpoint documentation with clearer descriptions of authentication requirements and response specifications across batch, ingest, health, user, and root endpoints
* Improved OpenAPI metadata to provide better API discoverability and integration guidance for developers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->