### PR TITLE
fix(settings): correct claude-code settings.json schema URL

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-config.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(git status:*)",


### PR DESCRIPTION
## Summary

- `.claude/settings.json` referenced `https://json.schemastore.org/claude-code-config.json`, which is not a published schema name. VSCode's Claude Code extension rejected the entire file with: *"Expected one of: https://json.schemastore.org/claude-code-settings.json. Permission rules and other settings from this file are not in effect."*
- Updated the `$schema` value to the canonical `claude-code-settings.json`. One-line change.
- Targeted at `feat/phase-1-core` because `.claude/settings.json` was introduced on that branch (commit 6cb5435, PR #31) and has not yet been merged to `main`.

## Impact

While the file was invalid, the local permission allowlist/denylist defined in it was silently ignored for any developer using VSCode. Restoring the correct schema URL re-enables those guardrails (including the `Bash(git push --force:*)` / `Bash(rm -rf:*)` deny entries).

## Test plan

- [x] `pre-commit run --files .claude/settings.json` passes (check-json + secrets scans)
- [ ] After merge, reopen the file in VSCode and confirm the schemastore validation banner is gone
- [ ] Confirm a previously-restricted Bash command (e.g. `rm -rf`) now triggers the deny rule as expected

Generated with [Claude Code](https://claude.com/claude-code)