### PR TITLE
ci(mutation): run mutation testing weekly only, drop PR trigger

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,28 +18,18 @@ on:
         required: false
         default: '80'
         type: string
-  # Run on PRs that modify source code
-  pull_request:
-    branches: [main, master, develop]
-    paths:
-      - 'src/**/*.py'
-      - 'tests/**/*.py'
-      - 'pyproject.toml'
 
-# Cancel in-progress runs for same PR/branch
+# Cancel in-progress runs for the same branch
 concurrency:
-  group: mutation-${{ github.event.pull_request.number || github.ref }}
+  group: mutation-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   mutation:
     name: Mutation Testing
-    # Skip on forks (no PR comment permissions)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@1b2d33c47cc11a96b9757b49f41873c54e75f57c # main
     with:
       python-version: '3.12'
@@ -47,6 +37,6 @@ jobs:
       test-directory: 'tests'
       mutation-threshold: ${{ github.event.inputs.mutation_threshold && fromJSON(github.event.inputs.mutation_threshold) || 80 }}
       fail-under-threshold: ${{ github.event_name != 'schedule' }}
-      post-pr-comment: true
+      post-pr-comment: false
       timeout-minutes: 60
       no-build: false


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from `.github/workflows/mutation-testing.yml`. Mutation testing was firing on every PR matching `src/`, `tests/`, or `pyproject.toml` and consuming a 60-minute runtime budget for informational output (mutation score is not a required check). The existing weekly cron is the appropriate cadence for this signal.

## What changes

- Drop the `pull_request:` trigger block
- Remove now-unused PR plumbing: `pull-requests: write` permission, fork-skip `if:` condition, and the `pull_request.number` fallback in the concurrency group
- Set `post-pr-comment: false` since there are no PR events to comment on

## What stays

- **Weekly schedule**: `cron: '0 2 * * 0'` (Sundays 02:00 UTC)
- **Manual trigger**: `workflow_dispatch` with the configurable `mutation_threshold` input
- **Enforcement asymmetry**: `fail-under-threshold: ${{ github.event_name != 'schedule' }}` is preserved, so manual runs still enforce the 80% threshold while the weekly cron remains report-only

Net diff: +3 / -13 lines.

## Test plan

- [ ] CI on this PR runs (note: this PR itself will no longer trigger mutation testing, by design)
- [ ] Sunday's scheduled run executes against `main` after merge
- [ ] Manual `workflow_dispatch` run still works and respects the threshold input

Generated with [Claude Code](https://claude.com/claude-code)