### PR TITLE
ci(mutation): normalize fail-under-threshold to opt-in workflow_dispatch

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -10,13 +10,18 @@ on:
   # Weekly schedule - Sundays at 2 AM UTC
   schedule:
     - cron: '0 2 * * 0'
-  # Manual trigger with configurable threshold
+  # Manual trigger with configurable threshold and opt-in failure
   workflow_dispatch:
     inputs:
       mutation_threshold:
         description: 'Minimum mutation score threshold (%)'
         required: false
         default: '80'
+        type: string
+      fail_under_threshold:
+        description: 'Fail the run if score is below threshold (default: false)'
+        required: false
+        default: 'false'
         type: string
 
 # Cancel in-progress runs for the same branch
@@ -36,7 +41,7 @@ jobs:
       source-directory: 'src'
       test-directory: 'tests'
       mutation-threshold: ${{ github.event.inputs.mutation_threshold && fromJSON(github.event.inputs.mutation_threshold) || 80 }}
-      fail-under-threshold: ${{ github.event_name != 'schedule' }}
+      fail-under-threshold: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.fail_under_threshold == 'true' }}
       post-pr-comment: false
       timeout-minutes: 60
       no-build: false


### PR DESCRIPTION
Normalizes `fail-under-threshold` to opt-in via a new `workflow_dispatch` input, enforcing manifest check **CI-053**. PR trigger was already removed in #35; this closes the latent regression where re-adding a trigger would have silently blocked merges, and makes manual dispatch report-only by default.

Generated with [Claude Code](https://claude.com/claude-code)