### PR TITLE
fix: close Phase 1 test infrastructure gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Vitest/Playwright conflict resolved**: `frontend/vitest.config.ts` now has an explicit
   `include` pattern restricting Vitest to `src/` so it no longer collects Playwright E2E specs
 
+### Fixed
+
+- **Test infrastructure gaps** (`fix/phase-1-completion`):
+  - Added `anyio[trio]` as an explicit dev dependency so `@pytest.mark.anyio`
+    tests in `test_auth_cloudflare.py` are not silently skipped if the
+    transitive dependency is dropped
+  - Narrowed `SecurityConfig.test_frozen` assertion from
+    `(AttributeError, TypeError)` to `dataclasses.FrozenInstanceError` for a
+    precise contract check; added `test_frozen_raises_on_bool_mutation` case
+  - Updated skipped WebSocket test reason to reference issue #44
+  - Applied `ruff format` to `test_middleware_security.py` (missed before commit)
+  - Resolved rebase conflicts with `main` across `test_time_utils.py`,
+    `test_middleware_security.py`, `test_auth_cloudflare.py`, and `ci.yml`
+
 ### Changed
 
 - Updated `.env.example` with Redis, Cloudflare, and pipeline configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "pytest-asyncio>=0.21.0",
+    "anyio[trio]>=4.0.0",      # async test runner used by pytest.mark.anyio
     "pytest-xdist>=3.3.0",
     "hypothesis>=6.82.0",
     "fakeredis>=2.32.1",    # In-memory Redis for testing

--- a/tests/unit/test_middleware_security.py
+++ b/tests/unit/test_middleware_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import time
 from unittest.mock import MagicMock
 
@@ -338,8 +339,14 @@ class TestSecurityConfig:
 
     def test_frozen(self) -> None:
         config = SecurityConfig()
-        with pytest.raises((AttributeError, TypeError)):
+        with pytest.raises(dataclasses.FrozenInstanceError, match="cannot assign"):
             config.rate_limit_rpm = 999  # type: ignore[misc]
+
+    def test_frozen_raises_on_bool_mutation(self) -> None:
+        config = SecurityConfig()
+        with pytest.raises(dataclasses.FrozenInstanceError, match="cannot assign"):
+            config.enable_rate_limiting = False  # type: ignore[misc]
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_middleware_security.py
+++ b/tests/unit/test_middleware_security.py
@@ -348,7 +348,6 @@ class TestSecurityConfig:
             config.enable_rate_limiting = False  # type: ignore[misc]
 
 
-
 # ---------------------------------------------------------------------------
 # add_security_middleware
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_time_utils.py
+++ b/tests/unit/test_time_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 
 import pytest
@@ -32,6 +33,12 @@ class TestUtcNow:
         result = utc_now()
         assert result.tzinfo == UTC
 
+    def test_is_close_to_current_time(self) -> None:
+        before = time.time()
+        now = utc_now()
+        after = time.time()
+        assert before <= now.timestamp() <= after
+
 
 class TestFromTimestamp:
     def test_known_epoch_zero(self) -> None:
@@ -42,7 +49,6 @@ class TestFromTimestamp:
         assert result.tzinfo == UTC
 
     def test_known_timestamp(self) -> None:
-        # 2022-01-01 00:00:00 UTC
         result = from_timestamp(1640995200)
         assert result.year == 2022
         assert result.month == 1

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -388,11 +388,8 @@ class TestWebSocketEndpoint:
         mock_cm.connect.assert_not_called()
 
     @pytest.mark.skip(
-        reason=(
-            "Module-level Redis import happens before patches can be applied. "
-            "Fix requires importlib.reload(rag_processor.websocket.router) after "
-            "patching redis.Redis, or refactoring the module to defer the import."
-        )
+        reason="Module-level Redis import fires before fakeredis patches; "
+        "tracked in https://github.com/ByronWilliamsCPA/rag-processor/issues/44"
     )
     @pytest.mark.asyncio
     async def test_websocket_accepts_valid_connection(

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
 ]
 
+[package.optional-dependencies]
+trio = [
+    { name = "trio" },
+]
+
 [[package]]
 name = "appnope"
 version = "0.1.4"
@@ -2620,6 +2625,18 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3662,6 +3679,7 @@ caching = [
     { name = "redis", extra = ["hiredis"] },
 ]
 dev = [
+    { name = "anyio", extra = ["trio"] },
     { name = "atheris", marker = "python_full_version >= '3.11'" },
     { name = "bandit" },
     { name = "basedpyright" },
@@ -3717,6 +3735,7 @@ supply-chain = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "alembic", marker = "extra == 'api'", specifier = ">=1.12.0" },
+    { name = "anyio", extras = ["trio"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "atheris", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=2.3.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.18.0" },
@@ -4281,6 +4300,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4539,6 +4567,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "trio"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Gap 1**: Added `include` pattern to `frontend/vitest.config.ts` so `npx vitest run` no longer collects Playwright e2e specs (was failing with a Playwright API conflict error)
- **Gap 2**: Added `playwright-e2e` job to CI with SHA-pinned `harden-runner`, Chromium install, `CLOUDFLARE_ENABLED=false` bypass mode, and artifact upload; updated `ci-gate` to require it; aligned `playwright.config.ts` webServer command to `npm run dev`
- **Gap 3**: Three backend modules brought from below-floor to target coverage:
  - `utils/time_utils.py`: 0% → 100% (new `test_time_utils.py`, 10 tests)
  - `middleware/security.py`: 36% → 91% (new `test_middleware_security.py`, 79 tests)
  - `auth/cloudflare.py`: 60% → 85% (new `test_auth_cloudflare.py`, 19 tests)
- **Minor**: Pre-existing skipped websocket test skip reason updated with GitHub issue reference ([#44](https://github.com/ByronWilliamsCPA/rag-processor/issues/44))

No application source code was modified. All changes are test files, config files, and the CI workflow.

## Test Plan

- [ ] `npx vitest run` passes without scoping to `src/` (Gap 1 fixed)
- [ ] `uv run pytest tests/ -q --cov=src --cov-fail-under=80` passes (442 passed, 1 skipped, 90.54% total)
- [ ] `middleware/security.py` ≥ 80% coverage
- [ ] `auth/cloudflare.py` ≥ 80% coverage
- [ ] `utils/time_utils.py` ≥ 80% coverage
- [ ] CI workflow YAML validates cleanly
- [ ] `playwright-e2e` job visible in GitHub Actions on this PR

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with bug fix entries.

* **Bug Fixes**
  * Pinned a development dependency to prevent test skips.
  * Strengthened security configuration immutability validation.

* **Tests**
  * Enhanced timestamp accuracy validation.
  * Improved test documentation and coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/rag-processor/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->