### PR TITLE
fix(ci): resolve startup_failure for compat matrix and release workflows

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -53,9 +53,6 @@ jobs:
       include-macos: false  # Disabled: python-magic requires libmagic (see note above)
       include-windows: false  # Disabled: python-magic requires libmagic DLL (see note above)
       source-directory: 'src'
-      # pyproject.toml's addopts includes --cov=src/rag_processor, so we need
-      # the dev extras (pytest-cov) installed for pytest to start.
-      extra-dependencies: 'dev'
       # Drop -m marker filter: the org reusable expands $TEST_COMMAND unquoted
       # via bash, which word-splits `-m "not slow and not integration"` into
       # broken tokens (pytest sees `slow` as a positional path arg). The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  # id-token and attestations: re-enable when publish-to-pypi is set to true
+  id-token: write      # required by the reusable's release job for artifact attestation
+  attestations: write  # required by the reusable's release job for artifact attestation
 
 # Uses org-level reusable workflow
 jobs:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -28,10 +28,9 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
-# Note: The org workflow uses 'permissions: read-all' which requires non-standard
-# permissions (artifact-metadata, attestations, models) that cannot be explicitly
-# granted in YAML. Remove permissions block to use default GITHUB_TOKEN permissions.
-# TODO: Report to .github team - org workflow should use explicit permissions
+permissions:
+  contents: read
+  security-events: write  # required by reusable's scan-runtime job for SARIF upload
 
 env:
   INFISICAL_DOMAIN: https://infisical.williamshome.family


### PR DESCRIPTION
## Summary

Three workflows were failing with `startup_failure` before any runner was provisioned. Root causes identified and fixed:

- **`python-compatibility.yml`**: Remove `extra-dependencies: 'dev'` -- this input does not exist in the org reusable at the pinned SHA. GitHub rejects unknown `with:` keys at workflow parse time. The reusable already runs `uv sync --all-extras` internally.
- **`release.yml`**: Restore `id-token: write` and `attestations: write` -- the reusable's `release` job always requests these for artifact attestation regardless of `publish-to-pypi` value. Incorrectly removed in PR #43.
- **`sbom.yml`**: Add `permissions: { contents: read, security-events: write }` -- the reusable's `scan-runtime` job declares `security-events: write` for SARIF upload. Since 2023, GitHub validates reusable permission grants at startup; the caller must grant every permission the callee's jobs request. The previous comment instructing to omit the permissions block was stale.

## Root cause detail

GitHub Actions validates two things at workflow graph evaluation time (before runners are provisioned):

1. **Unknown `with:` inputs**: the callee's `inputs:` schema must declare every key the caller passes -- unknown keys produce an immediate `startup_failure`.
2. **Missing permission grants (since 2023)**: if the caller's `permissions:` block does not include a permission that a callee job explicitly declares, GitHub fails the workflow at startup.

## Test plan

- [ ] `Python Compatibility`: transitions from `startup_failure` to running
- [ ] `Semantic Release`: transitions from `startup_failure` to running (may still fail later without PyPI, but should start)
- [ ] `SBOM & Security Scan`: transitions from `startup_failure` to running

Generated with [Claude Code](https://claude.ai/claude-code)