### PR TITLE
fix(claude): restore .claude/settings.json $schema URL

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-config.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [],
     "deny": []


### PR DESCRIPTION
## Problem

Claude Code refuses to load `.claude/settings.json` and prints:

> Settings file failed to parse: /home/byron/dev/rag_processor/.claude/settings.json — Invalid value. Expected one of: \"https://json.schemastore.org/claude-code-settings.json\". Permission rules and other settings from this file are not in effect.

The file's `\$schema` pointed at `claude-code-config.json` instead of the required `claude-code-settings.json`. Claude Code does not fail closed on this mismatch; it just shows the banner and ignores every permission rule in the file.

## Fix

One-line change: `claude-code-config.json` → `claude-code-settings.json`.

```diff
-  \"\$schema\": \"https://json.schemastore.org/claude-code-config.json\",
+  \"\$schema\": \"https://json.schemastore.org/claude-code-settings.json\",
```

## History

This is the same defect that PR #51 fixed previously. PR #48's compliance-alignment sweep reintroduced the wrong slug, likely because an upstream audit template still ships the bad URL.

## Verification

- [x] `python3 -c \"import json; json.load(open('.claude/settings.json'))\"` — valid JSON
- [x] `pre-commit run --files .claude/settings.json` — all hooks pass
- [x] No em-dashes
- [ ] Banner disappears on next Claude Code session restart

Refs: project memory `feedback_claude_settings_schema_url.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)