### PR TITLE
chore(security): pin Docker images by SHA digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Builder - Install dependencies
 # =============================================================================
-FROM python:3.12-slim AS builder
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install UV for fast dependency management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uv /usr/local/bin/uv
 
 # Copy dependency files
 COPY pyproject.toml uv.lock ./
@@ -34,7 +34,7 @@ RUN uv sync --frozen --no-dev
 # =============================================================================
 # Stage 2: Runtime - Minimal production image
 # =============================================================================
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 # Metadata labels (OCI standard)
 LABEL org.opencontainers.image.title="RAG Processor"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Dependencies
 # =============================================================================
-FROM node:22-alpine AS deps
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS deps
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN npm ci --only=production=false
 # =============================================================================
 # Stage 2: Builder
 # =============================================================================
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
 
 WORKDIR /app
 
@@ -37,7 +37,7 @@ RUN npm run build
 # =============================================================================
 # Stage 3: Production (nginx)
 # =============================================================================
-FROM nginx:alpine AS production
+FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a AS production
 
 # Metadata labels
 LABEL org.opencontainers.image.title="RAG Processor Frontend"
@@ -74,7 +74,7 @@ CMD ["nginx", "-g", "daemon off;"]
 # =============================================================================
 # Stage 4: Development (optional - for docker-compose dev)
 # =============================================================================
-FROM node:22-alpine AS development
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS development
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Pin Docker base images by SHA digest to fix OpenSSF Scorecard Pinned-Dependencies findings.

- `python:3.12-slim` -> `@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203` (all stages)
- `ghcr.io/astral-sh/uv:latest` -> `ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d`
- node:22-alpine -> @sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 (3 stages in frontend/Dockerfile)
- nginx:alpine -> @sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a (production stage in frontend/Dockerfile)

## Why
Same root cause as ByronWilliamsCPA/llc-manager#51. Floating tags break supply-chain integrity; immutable digests make the build deterministic and the Scorecard score climb by ~1.0-1.5.

## How the SHAs were resolved
- python:3.12-slim digest from Docker Hub tag API (last_updated 2026-05-22)
- uv digest from GHCR OCI registry manifest; the 0.11.16 version tag added alongside digest so Renovate can auto-bump
- node:22-alpine and nginx:alpine digests from Docker Hub tag API (last_updated 2026-05-14 and 2026-05-24 respectively)

## Test plan
- [ ] CI passes (no functional change)
- [ ] Container security gate still satisfied
- [ ] Next Scorecard run shows Pinned-Dependencies score increase

Generated with [Claude Code](https://claude.com/claude-code)