### PR TITLE
feat: unify Redis access, wire ingest pipeline, consolidate auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Ingestion Pipeline & Architecture Review
+
+- **Background ingestion pipeline** wired end-to-end: uploaded batches/jobs are
+  persisted to Redis and enqueued to RQ, gated behind the new default-off
+  `RAG_PROCESSOR_ENQUEUE_ENABLED` setting so deployments without an RQ worker
+  keep accepting uploads. Enqueue is all-or-nothing (partial failures roll back
+  Redis state and cancel enqueued jobs); the worker records failures
+  best-effort and skips jobs whose parent batch has disappeared.
+- **Unified synchronous Redis client** (`core/redis.py`) with shared, lazily
+  built (thread-safe) connection pools and graceful shutdown, replacing
+  per-module client construction. Async handlers use non-blocking
+  `get_batch_status_async` / `get_job_status_async` wrappers.
+- **Consolidated Cloudflare JWT validation**: HTTP-middleware and WebSocket
+  paths share one JWKS loader (with single-flight refresh lock) and decode
+  helper, so both enforce the same RS256 + audience + issuer checks and clock-skew leeway.
+- **Domain exception hierarchy wired into FastAPI** via an exception handler
+  mapping `ProjectBaseError` subclasses to HTTP responses.
+
 #### Phase 0: Foundation Infrastructure
 
 - **FastAPI Gateway**: Main application entry point (`src/rag_processor/main.py`)

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -5,7 +5,6 @@ Provides endpoints for querying batch and job status.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 from uuid import UUID
 
@@ -22,7 +21,7 @@ from rag_processor.models.job import (
     JobStatus,
     Pipeline,
 )
-from rag_processor.queue.jobs import get_batch_status, get_job_status
+from rag_processor.queue.jobs import get_batch_status_async, get_job_status_async
 from rag_processor.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -126,9 +125,8 @@ async def get_batch(
     Raises:
         HTTPException: 404 if batch not found or caller does not own it.
     """
-    # Offload the synchronous Redis read to a thread so it does not block the
-    # event loop (see core/redis.py / queue.jobs async wrappers).
-    batch, jobs = await asyncio.to_thread(get_batch_status, batch_id)
+    # Non-blocking Redis read (offloaded to a thread inside the wrapper).
+    batch, jobs = await get_batch_status_async(batch_id)
 
     # Return 404 (not 403) for non-owners to avoid leaking batch existence.
     if batch is None or not batch_is_owned_by(
@@ -217,7 +215,7 @@ async def get_job(
     Raises:
         HTTPException: 404 if job not found or caller does not own its batch.
     """
-    job = await asyncio.to_thread(get_job_status, job_id)
+    job = await get_job_status_async(job_id)
 
     if job is None:
         raise HTTPException(
@@ -226,7 +224,7 @@ async def get_job(
         )
 
     # A job inherits ownership from its parent batch.
-    batch, _ = await asyncio.to_thread(get_batch_status, job.batch_id)
+    batch, _ = await get_batch_status_async(job.batch_id)
     if batch is None or not batch_is_owned_by(
         batch, requester_user_id=user.user_id, requester_email=user.email
     ):

--- a/src/rag_processor/api/batch.py
+++ b/src/rag_processor/api/batch.py
@@ -5,6 +5,7 @@ Provides endpoints for querying batch and job status.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Annotated
 from uuid import UUID
 
@@ -125,7 +126,9 @@ async def get_batch(
     Raises:
         HTTPException: 404 if batch not found or caller does not own it.
     """
-    batch, jobs = get_batch_status(batch_id)
+    # Offload the synchronous Redis read to a thread so it does not block the
+    # event loop (see core/redis.py / queue.jobs async wrappers).
+    batch, jobs = await asyncio.to_thread(get_batch_status, batch_id)
 
     # Return 404 (not 403) for non-owners to avoid leaking batch existence.
     if batch is None or not batch_is_owned_by(
@@ -214,7 +217,7 @@ async def get_job(
     Raises:
         HTTPException: 404 if job not found or caller does not own its batch.
     """
-    job = get_job_status(job_id)
+    job = await asyncio.to_thread(get_job_status, job_id)
 
     if job is None:
         raise HTTPException(
@@ -223,7 +226,7 @@ async def get_job(
         )
 
     # A job inherits ownership from its parent batch.
-    batch, _ = get_batch_status(job.batch_id)
+    batch, _ = await asyncio.to_thread(get_batch_status, job.batch_id)
     if batch is None or not batch_is_owned_by(
         batch, requester_user_id=user.user_id, requester_email=user.email
     ):

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -217,7 +217,18 @@ async def _persist_and_enqueue(
             "Failed to persist/enqueue batch",
             batch_id=str(batch.batch_id),
         )
-        shutil.rmtree(batch_dir, ignore_errors=True)
+        # Clean up the on-disk uploads, but log rather than silently swallow a
+        # cleanup failure (ignore_errors=True would hide leaked files). Wrapping
+        # rmtree in try/except is version-agnostic; the onexc/onerror callback
+        # API differs across the supported 3.11 to 3.14 range.
+        try:
+            shutil.rmtree(batch_dir)
+        except OSError as cleanup_exc:
+            logger.warning(
+                "Failed to remove upload dir during rollback; files may be leaked",
+                path=str(batch_dir),
+                error=str(cleanup_exc),
+            )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=(

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -29,7 +29,6 @@ from rag_processor.models.job import (
     Priority,
 )
 from rag_processor.queue.jobs import enqueue_batch_jobs
-from rag_processor.queue.redis_store import get_redis_store
 from rag_processor.routing import FileRouter
 from rag_processor.utils.logging import get_logger
 
@@ -211,20 +210,13 @@ async def _persist_and_enqueue(
     try:
         await asyncio.to_thread(enqueue_batch_jobs, batch, jobs)
     except Exception as exc:
-        # Infra boundary: roll back on any Redis/RQ failure so we never report
-        # success for work that will not be processed.
+        # enqueue_batch_jobs rolls back its own Redis/RQ state atomically on
+        # failure; here we only clean up the on-disk uploads and surface the
+        # error so we never report success for work that will not be processed.
         logger.exception(
-            "Failed to persist/enqueue batch; rolling back",
+            "Failed to persist/enqueue batch",
             batch_id=str(batch.batch_id),
         )
-        # Best-effort rollback of partially-written Redis state and uploads.
-        try:
-            await asyncio.to_thread(get_redis_store().delete_batch, batch.batch_id)
-        except Exception:  # noqa: BLE001 - rollback is best-effort
-            logger.warning(
-                "Failed to roll back Redis state for batch",
-                batch_id=str(batch.batch_id),
-            )
         shutil.rmtree(batch_dir, ignore_errors=True)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -333,6 +333,16 @@ async def ingest_files(
             file_path = batch_dir / f"{name}_{counter}{ext}"
             counter += 1
 
+        # Defense-in-depth: ensure the resolved path stays within batch_dir.
+        # sanitize_filename already strips path components, so this is not
+        # reachable today; it is a second containment guard before any write in
+        # case the sanitizer ever regresses.
+        if not file_path.resolve().is_relative_to(batch_dir.resolve()):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid filename: {original_filename}",
+            )
+
         # Save file
         async with aiofiles.open(file_path, "wb") as f:
             await f.write(content)

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -5,7 +5,9 @@ Provides endpoints for uploading files for RAG pipeline processing.
 
 from __future__ import annotations
 
+import asyncio
 import re
+import shutil
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -26,6 +28,8 @@ from rag_processor.models.job import (
     Pipeline,
     Priority,
 )
+from rag_processor.queue.jobs import enqueue_batch_jobs
+from rag_processor.queue.redis_store import get_redis_store
 from rag_processor.routing import FileRouter
 from rag_processor.utils.logging import get_logger
 
@@ -185,6 +189,51 @@ async def validate_file(
     return content, mime_type, errors
 
 
+async def _persist_and_enqueue(
+    batch: Batch,
+    jobs: list[Job],
+    batch_dir: Path,
+) -> None:
+    """Persist a batch/jobs to Redis and enqueue them for processing.
+
+    Runs the synchronous enqueue off the event loop. On failure, rolls back the
+    persisted Redis state and the on-disk upload directory, then raises so the
+    client receives an error instead of a false success.
+
+    Args:
+        batch: The batch to persist and enqueue.
+        jobs: The jobs belonging to the batch.
+        batch_dir: The on-disk directory holding the uploaded files.
+
+    Raises:
+        HTTPException: 503 if persistence/enqueue fails.
+    """
+    try:
+        await asyncio.to_thread(enqueue_batch_jobs, batch, jobs)
+    except Exception as exc:
+        # Infra boundary: roll back on any Redis/RQ failure so we never report
+        # success for work that will not be processed.
+        logger.exception(
+            "Failed to persist/enqueue batch; rolling back",
+            batch_id=str(batch.batch_id),
+        )
+        # Best-effort rollback of partially-written Redis state and uploads.
+        try:
+            await asyncio.to_thread(get_redis_store().delete_batch, batch.batch_id)
+        except Exception:  # noqa: BLE001 - rollback is best-effort
+            logger.warning(
+                "Failed to roll back Redis state for batch",
+                batch_id=str(batch.batch_id),
+            )
+        shutil.rmtree(batch_dir, ignore_errors=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Upload accepted but could not be queued for processing. Please retry."
+            ),
+        ) from exc
+
+
 @router.post(
     "",
     response_model=IngestResponse,
@@ -327,8 +376,12 @@ async def ingest_files(
     # Update batch with actual valid file count
     batch.total_files = len(jobs)
 
-    # TODO: Store batch and jobs in Redis (Sprint 1.14)
-    # TODO: Enqueue jobs in RQ (Sprint 1.14)
+    # Persist the batch/jobs to Redis and enqueue them for background
+    # processing. Gated behind a setting so deployments without a Redis/RQ
+    # worker still accept uploads without attempting to queue them. The Redis
+    # client is synchronous, so run the enqueue off the event loop.
+    if settings.enqueue_enabled:
+        await _persist_and_enqueue(batch, jobs, batch_dir)
 
     logger.info(
         "Batch created",

--- a/src/rag_processor/auth/cloudflare.py
+++ b/src/rag_processor/auth/cloudflare.py
@@ -113,12 +113,75 @@ async def _load_jwks(*, force_refresh: bool = False) -> JWKSData:
         async with httpx.AsyncClient() as client:  # nosec B113 - timeout below
             response = await client.get(jwks_url, timeout=10.0)
             response.raise_for_status()
-            jwks: JWKSData = response.json()
+            raw_payload: object = response.json()
+            jwks, keys_count = _parse_jwks_payload(raw_payload)
 
         _jwks_cache.update(jwks)
-        keys_list: list[Any] = jwks.get("keys", [])
-        logger.debug("Refreshed JWKS cache", keys_count=len(keys_list))
+        logger.debug("Refreshed JWKS cache", keys_count=keys_count)
         return jwks
+
+
+def _parse_jwks_payload(payload: object) -> tuple[JWKSData, int]:
+    """Validate a raw JWKS payload at the trust boundary before caching.
+
+    Cloudflare's certs endpoint is trusted, but the response is still untyped
+    JSON entering the auth path. Reject anything that is not an object with a
+    ``keys`` list of objects each carrying a string ``kid`` so malformed data
+    fails fast here instead of surfacing later during key resolution.
+
+    Args:
+        payload: The decoded JSON body from the JWKS endpoint.
+
+    Returns:
+        A tuple of the validated JWKS document and its key count.
+
+    Raises:
+        jwt.InvalidTokenError: If the payload shape is invalid.
+    """
+    if not isinstance(payload, dict):
+        msg = "JWKS payload is not a JSON object"
+        raise jwt.InvalidTokenError(msg)
+    raw_keys: object = payload.get("keys")
+    if not isinstance(raw_keys, list):
+        msg = "JWKS payload missing 'keys' list"
+        raise jwt.InvalidTokenError(msg)
+    keys: list[dict[str, object]] = []
+    for key in raw_keys:
+        if not isinstance(key, dict) or not isinstance(key.get("kid"), str):
+            msg = "JWKS key entry missing string 'kid'"
+            raise jwt.InvalidTokenError(msg)
+        keys.append(key)
+    return {"keys": keys}, len(keys)
+
+
+async def _resolve_signing_key(jwks: JWKSData, token: str) -> RSAPublicKey:
+    """Resolve a token's signing key, refreshing JWKS once on a key miss.
+
+    Cloudflare rotates Access signing keys within the cache TTL. On a missing
+    ``kid`` we force-refresh the JWKS and retry once so a valid token signed
+    with a freshly rotated key is not rejected until the cache expires.
+
+    # #CRITICAL: Security: auth flow — a stale JWKS cache must not reject
+    # tokens signed by a freshly rotated Cloudflare key (user-facing outage).
+    # #VERIFY: force-refresh and retry key resolution exactly once on a miss.
+
+    Args:
+        jwks: The currently cached JWKS document.
+        token: The JWT whose signing key is being resolved.
+
+    Returns:
+        The matching RSA public key.
+
+    Raises:
+        jwt.InvalidTokenError: If the key is missing even after a refresh.
+    """
+    try:
+        return _resolve_key_or_raise(jwks, token)
+    except jwt.InvalidTokenError as exc:
+        if "not found in JWKS" not in str(exc):
+            raise
+        refreshed = await _load_jwks(force_refresh=True)
+        return _resolve_key_or_raise(refreshed, token)
 
 
 def _select_rsa_key(jwks: JWKSData, kid: str) -> RSAPublicKey | None:
@@ -309,7 +372,7 @@ class CloudflareAuthMiddleware(BaseHTTPMiddleware):
         # validate/decode via the shared helpers (same logic as the WebSocket
         # path).
         jwks = await self._get_jwks()
-        rsa_key = _resolve_key_or_raise(jwks, token)
+        rsa_key = await _resolve_signing_key(jwks, token)
         payload = _decode_cf_jwt(token, rsa_key)
 
         # Parse claims and create user
@@ -381,7 +444,7 @@ async def verify_cloudflare_token(token: str) -> dict[str, Any]:
     # the HTTP middleware so HTTP and WebSocket auth accept identical tokens
     # (including the shared clock-skew leeway).
     jwks = await _load_jwks()
-    rsa_key = _resolve_key_or_raise(jwks, token)
+    rsa_key = await _resolve_signing_key(jwks, token)
     payload = _decode_cf_jwt(token, rsa_key)
 
     # Extract user info

--- a/src/rag_processor/auth/cloudflare.py
+++ b/src/rag_processor/auth/cloudflare.py
@@ -104,9 +104,17 @@ async def _load_jwks(*, force_refresh: bool = False) -> JWKSData:
     if not force_refresh and _jwks_cache.is_valid():
         return _jwks_cache.data
 
+    # Snapshot before contending for the lock so we can detect a refresh that
+    # another coroutine completed while we waited (covers the force_refresh
+    # path too, where the is_valid() re-check alone would not short-circuit).
+    cache_ts_before_lock = _jwks_cache.timestamp
+
     async with _jwks_lock:
-        # Another coroutine may have refreshed while we waited for the lock.
-        if not force_refresh and _jwks_cache.is_valid():
+        # Another coroutine may have refreshed while we waited for the lock. For
+        # a normal load a valid cache is enough; for a forced refresh, only a
+        # refresh newer than our snapshot counts as fresh enough to reuse.
+        refreshed_during_wait = _jwks_cache.timestamp != cache_ts_before_lock
+        if _jwks_cache.is_valid() and (not force_refresh or refreshed_during_wait):
             return _jwks_cache.data
 
         jwks_url = f"https://{settings.cloudflare_team_domain}/cdn-cgi/access/certs"

--- a/src/rag_processor/auth/cloudflare.py
+++ b/src/rag_processor/auth/cloudflare.py
@@ -6,6 +6,7 @@ Supports bypass mode for local development without Cloudflare.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -70,6 +71,117 @@ class _JWKSCache:
 
 
 _jwks_cache = _JWKSCache()
+
+# Serializes concurrent JWKS refreshes so a cache miss under load triggers a
+# single upstream fetch instead of a stampede against Cloudflare's endpoint.
+_jwks_lock = asyncio.Lock()
+
+# Leeway (seconds) applied to JWT exp/iat/nbf to tolerate minor clock skew.
+# Shared by the HTTP middleware and the WebSocket verification path so both
+# accept exactly the same tokens.
+_JWT_LEEWAY_SECONDS = 5
+
+
+async def _load_jwks(*, force_refresh: bool = False) -> JWKSData:
+    """Return JWKS, fetching from Cloudflare on cache miss under a lock.
+
+    Uses double-checked locking: the common case (valid cache) returns without
+    acquiring the lock; on a miss, the lock is taken and the cache re-checked so
+    only one coroutine performs the upstream fetch.
+
+    Args:
+        force_refresh: If True, bypass the cached value and refetch.
+
+    Returns:
+        The JWKS dictionary with public keys.
+    """
+    if not force_refresh and _jwks_cache.is_valid():
+        return _jwks_cache.data
+
+    async with _jwks_lock:
+        # Another coroutine may have refreshed while we waited for the lock.
+        if not force_refresh and _jwks_cache.is_valid():
+            return _jwks_cache.data
+
+        jwks_url = f"https://{settings.cloudflare_team_domain}/cdn-cgi/access/certs"
+        async with httpx.AsyncClient() as client:  # nosec B113 - timeout below
+            response = await client.get(jwks_url, timeout=10.0)
+            response.raise_for_status()
+            jwks: JWKSData = response.json()
+
+        _jwks_cache.update(jwks)
+        keys_list: list[Any] = jwks.get("keys", [])
+        logger.debug("Refreshed JWKS cache", keys_count=len(keys_list))
+        return jwks
+
+
+def _select_rsa_key(jwks: JWKSData, kid: str) -> RSAPublicKey | None:
+    """Find the RSA public key matching ``kid`` in a JWKS document.
+
+    Args:
+        jwks: JWKS dictionary.
+        kid: Key ID to find.
+
+    Returns:
+        The RSA public key, or None if no key matches.
+    """
+    keys_list: list[dict[str, Any]] = jwks.get("keys", [])
+    for key in keys_list:
+        if key.get("kid") == kid:
+            return RSAAlgorithm.from_jwk(key)  # type: ignore[return-value]
+    return None
+
+
+def _decode_cf_jwt(token: str, rsa_key: RSAPublicKey) -> dict[str, Any]:
+    """Validate and decode a Cloudflare Access JWT.
+
+    Single source of truth for signature/audience/issuer validation and clock
+    skew handling, shared by the HTTP middleware and the WebSocket path.
+
+    Args:
+        token: The JWT string.
+        rsa_key: The RSA public key to verify the signature against.
+
+    Returns:
+        The decoded token payload (claims).
+
+    Raises:
+        jwt.InvalidTokenError: If the token fails validation.
+    """
+    return jwt.decode(
+        token,
+        rsa_key,
+        algorithms=["RS256"],
+        audience=settings.cloudflare_audience_tag,
+        issuer=f"https://{settings.cloudflare_team_domain}",
+        leeway=_JWT_LEEWAY_SECONDS,
+    )
+
+
+def _resolve_key_or_raise(jwks: JWKSData, token: str) -> RSAPublicKey:
+    """Extract the ``kid`` from a token and resolve its RSA key.
+
+    Args:
+        jwks: JWKS dictionary.
+        token: The JWT string (header is read unverified to get the ``kid``).
+
+    Returns:
+        The matching RSA public key.
+
+    Raises:
+        jwt.InvalidTokenError: If the token has no ``kid`` or no key matches.
+    """
+    unverified_header = jwt.get_unverified_header(token)
+    kid = unverified_header.get("kid")
+    if not kid:
+        msg = "Token missing key ID"
+        raise jwt.InvalidTokenError(msg)
+
+    rsa_key = _select_rsa_key(jwks, kid)
+    if not rsa_key:
+        msg = f"Key {kid} not found in JWKS"
+        raise jwt.InvalidTokenError(msg)
+    return rsa_key
 
 
 class CloudflareAuthMiddleware(BaseHTTPMiddleware):
@@ -187,33 +299,12 @@ class CloudflareAuthMiddleware(BaseHTTPMiddleware):
         Raises:
             InvalidTokenError: If token is invalid or key not found.
         """
-        # Get JWKS for signature validation
+        # Get JWKS for signature validation, resolve the signing key, then
+        # validate/decode via the shared helpers (same logic as the WebSocket
+        # path).
         jwks = await self._get_jwks()
-
-        # Decode header to get key ID
-        unverified_header = jwt.get_unverified_header(token)
-        kid = unverified_header.get("kid")
-
-        if not kid:
-            msg = "Token missing key ID"
-            raise jwt.InvalidTokenError(msg)
-
-        # Find matching key
-        rsa_key = self._find_key(jwks, kid)
-        if not rsa_key:
-            msg = f"Key {kid} not found in JWKS"
-            raise jwt.InvalidTokenError(msg)
-
-        # Validate and decode token
-        # Use leeway to handle slight clock skew between systems
-        payload = jwt.decode(
-            token,
-            rsa_key,
-            algorithms=["RS256"],
-            audience=settings.cloudflare_audience_tag,
-            issuer=f"https://{settings.cloudflare_team_domain}",
-            leeway=5,  # 5 seconds leeway for clock skew
-        )
+        rsa_key = _resolve_key_or_raise(jwks, token)
+        payload = _decode_cf_jwt(token, rsa_key)
 
         # Parse claims and create user
         claims = TokenClaims(**payload)
@@ -222,26 +313,13 @@ class CloudflareAuthMiddleware(BaseHTTPMiddleware):
     async def _get_jwks(self) -> JWKSData:
         """Fetch JWKS from Cloudflare with caching.
 
+        Thin wrapper around the shared :func:`_load_jwks` loader. Kept as an
+        instance method so it remains an overridable seam for tests.
+
         Returns:
             JWKS dictionary with public keys.
         """
-        # Return cached JWKS if still valid
-        if _jwks_cache.is_valid():
-            return _jwks_cache.data
-
-        # Fetch fresh JWKS
-        jwks_url = f"https://{settings.cloudflare_team_domain}/cdn-cgi/access/certs"
-        async with httpx.AsyncClient() as client:  # nosec B113 - timeout is specified below
-            response = await client.get(jwks_url, timeout=10.0)
-            response.raise_for_status()
-            jwks: JWKSData = response.json()
-
-        # Update cache
-        _jwks_cache.update(jwks)
-
-        keys_list: list[Any] = jwks.get("keys", [])
-        logger.debug("Refreshed JWKS cache", keys_count=len(keys_list))
-        return jwks
+        return await _load_jwks()
 
     def _find_key(self, jwks: JWKSData, kid: str) -> RSAPublicKey | None:
         """Find RSA key by key ID in JWKS.
@@ -253,11 +331,7 @@ class CloudflareAuthMiddleware(BaseHTTPMiddleware):
         Returns:
             RSA public key or None if not found.
         """
-        keys_list: list[dict[str, Any]] = jwks.get("keys", [])
-        for key in keys_list:
-            if key.get("kid") == kid:
-                return RSAAlgorithm.from_jwk(key)  # type: ignore[return-value]
-        return None
+        return _select_rsa_key(jwks, kid)
 
     def _unauthorized_response(self, detail: str) -> JSONResponse:
         """Create 401 Unauthorized response.
@@ -297,45 +371,12 @@ async def verify_cloudflare_token(token: str) -> dict[str, Any]:
     Raises:
         InvalidTokenError: If token is invalid or expired.
     """
-    # Get JWKS for signature validation
-    if not _jwks_cache.is_valid():
-        jwks_url = f"https://{settings.cloudflare_team_domain}/cdn-cgi/access/certs"
-        async with httpx.AsyncClient() as client:  # nosec B113 - timeout below
-            response = await client.get(jwks_url, timeout=10.0)
-            response.raise_for_status()
-            jwks: JWKSData = response.json()
-        _jwks_cache.update(jwks)
-
-    jwks = _jwks_cache.data
-
-    # Decode header to get key ID
-    unverified_header = jwt.get_unverified_header(token)
-    kid = unverified_header.get("kid")
-
-    if not kid:
-        msg = "Token missing key ID"
-        raise jwt.InvalidTokenError(msg)
-
-    # Find matching key
-    rsa_key: RSAPublicKey | None = None
-    keys_list: list[dict[str, Any]] = jwks.get("keys", [])
-    for key in keys_list:
-        if key.get("kid") == kid:
-            rsa_key = RSAAlgorithm.from_jwk(key)  # type: ignore[assignment]
-            break
-
-    if not rsa_key:
-        msg = f"Key {kid} not found in JWKS"
-        raise jwt.InvalidTokenError(msg)
-
-    # Validate and decode token
-    payload = jwt.decode(
-        token,
-        rsa_key,
-        algorithms=["RS256"],
-        audience=settings.cloudflare_audience_tag,
-        issuer=f"https://{settings.cloudflare_team_domain}",
-    )
+    # Reuse the exact same JWKS loading, key resolution, and decode logic as
+    # the HTTP middleware so HTTP and WebSocket auth accept identical tokens
+    # (including the shared clock-skew leeway).
+    jwks = await _load_jwks()
+    rsa_key = _resolve_key_or_raise(jwks, token)
+    payload = _decode_cf_jwt(token, rsa_key)
 
     # Extract user info
     return {

--- a/src/rag_processor/auth/cloudflare.py
+++ b/src/rag_processor/auth/cloudflare.py
@@ -74,6 +74,12 @@ _jwks_cache = _JWKSCache()
 
 # Serializes concurrent JWKS refreshes so a cache miss under load triggers a
 # single upstream fetch instead of a stampede against Cloudflare's endpoint.
+#
+# Created at import time. On Python 3.10+ this binds to the running loop lazily
+# on first await, and the app runs a single event loop, so this is safe in
+# production. The only latent risk is tests that spin up multiple event loops
+# and share this module-level lock across them; if that ever arises, construct
+# the lock inside the loop (e.g. a lazily-initialised per-loop lock) instead.
 _jwks_lock = asyncio.Lock()
 
 # Leeway (seconds) applied to JWT exp/iat/nbf to tolerate minor clock skew.

--- a/src/rag_processor/core/config.py
+++ b/src/rag_processor/core/config.py
@@ -72,6 +72,17 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Background processing
+    enqueue_enabled: bool = Field(
+        default=False,
+        description=(
+            "Persist uploaded batches/jobs to Redis and enqueue them to RQ for "
+            "background processing. Disabled by default so deployments without "
+            "a Redis/RQ worker accept uploads without attempting to queue them. "
+            "Set to true once a worker is running."
+        ),
+    )
+
     # Rate Limiting
     rate_limiting_enabled: bool = Field(
         default=True,

--- a/src/rag_processor/core/exceptions.py
+++ b/src/rag_processor/core/exceptions.py
@@ -34,6 +34,7 @@ Usage:
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 
 
@@ -442,21 +443,21 @@ def http_status_for(exc: ProjectBaseError) -> int:
     # Ordered most-specific-first so subclasses (e.g. DatabaseError, which
     # extends ExternalServiceError) match before their base classes.
     status_by_type: tuple[tuple[type[ProjectBaseError], int], ...] = (
-        (DatabaseError, 503),
-        (APIError, 502),
-        (ExternalServiceError, 502),
-        (AuthenticationError, 401),
-        (AuthorizationError, 403),
-        (ResourceNotFoundError, 404),
-        (ValidationError, 400),
-        (BusinessLogicError, 409),
-        (ConfigurationError, 500),
+        (DatabaseError, HTTPStatus.SERVICE_UNAVAILABLE),
+        (APIError, HTTPStatus.BAD_GATEWAY),
+        (ExternalServiceError, HTTPStatus.BAD_GATEWAY),
+        (AuthenticationError, HTTPStatus.UNAUTHORIZED),
+        (AuthorizationError, HTTPStatus.FORBIDDEN),
+        (ResourceNotFoundError, HTTPStatus.NOT_FOUND),
+        (ValidationError, HTTPStatus.BAD_REQUEST),
+        (BusinessLogicError, HTTPStatus.CONFLICT),
+        (ConfigurationError, HTTPStatus.INTERNAL_SERVER_ERROR),
     )
     for exc_type, http_status in status_by_type:
         if isinstance(exc, exc_type):
-            return http_status
+            return int(http_status)
     # Base ProjectBaseError or any unmapped subclass.
-    return 500
+    return int(HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 # Export all exceptions

--- a/src/rag_processor/core/exceptions.py
+++ b/src/rag_processor/core/exceptions.py
@@ -426,6 +426,39 @@ class BusinessLogicError(ProjectBaseError):
         )
 
 
+def http_status_for(exc: ProjectBaseError) -> int:
+    """Map a project exception to an HTTP status code.
+
+    Used by the FastAPI exception handler so domain exceptions raised anywhere
+    in the application are translated into consistent HTTP responses. Subclasses
+    are checked before their base classes.
+
+    Args:
+        exc: The project exception instance.
+
+    Returns:
+        The HTTP status code to return for this exception.
+    """
+    # Ordered most-specific-first so subclasses (e.g. DatabaseError, which
+    # extends ExternalServiceError) match before their base classes.
+    status_by_type: tuple[tuple[type[ProjectBaseError], int], ...] = (
+        (DatabaseError, 503),
+        (APIError, 502),
+        (ExternalServiceError, 502),
+        (AuthenticationError, 401),
+        (AuthorizationError, 403),
+        (ResourceNotFoundError, 404),
+        (ValidationError, 400),
+        (BusinessLogicError, 409),
+        (ConfigurationError, 500),
+    )
+    for exc_type, http_status in status_by_type:
+        if isinstance(exc, exc_type):
+            return http_status
+    # Base ProjectBaseError or any unmapped subclass.
+    return 500
+
+
 # Export all exceptions
 __all__ = [
     "APIError",
@@ -438,4 +471,5 @@ __all__ = [
     "ProjectBaseError",
     "ResourceNotFoundError",
     "ValidationError",
+    "http_status_for",
 ]

--- a/src/rag_processor/core/redis.py
+++ b/src/rag_processor/core/redis.py
@@ -1,0 +1,98 @@
+"""Centralized synchronous Redis client construction.
+
+RQ (the job queue) requires a *synchronous* redis-py client, and the worker
+process shares Redis with the API. Rather than have ``queue/client.py``,
+``queue/redis_store.py`` and ``websocket/events.py`` each hand-roll their own
+``redis.Redis(...)`` with duplicated connection kwargs (and no shared pool or
+cleanup), every sync consumer builds its client here from a process-wide
+connection pool.
+
+Two pools are maintained because ``decode_responses`` is a connection-level
+setting in redis-py and cannot be mixed within a single pool:
+
+* the **decoded** pool returns ``str`` responses and backs application data
+  (``RedisStore``) and event publishing (``websocket/events.py``);
+* the **raw** pool returns ``bytes`` responses and backs RQ, which requires
+  un-decoded payloads.
+
+IMPORTANT: these clients are synchronous. Async HTTP/WebSocket handlers must
+never call them directly on the event loop; use the ``*_async`` helpers in
+``rag_processor.queue.jobs`` which offload the blocking call to a worker
+thread via ``asyncio.to_thread``.
+"""
+
+from __future__ import annotations
+
+import redis
+
+from rag_processor.core.config import settings
+from rag_processor.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Process-wide connection pools, created lazily on first use.
+_decoded_pool: redis.ConnectionPool | None = None
+_raw_pool: redis.ConnectionPool | None = None
+
+
+def _build_pool(*, decode_responses: bool) -> redis.ConnectionPool:
+    """Build a Redis connection pool from application settings.
+
+    Args:
+        decode_responses: Whether connections decode responses to ``str``.
+
+    Returns:
+        A configured Redis connection pool.
+    """
+    return redis.ConnectionPool(
+        host=settings.redis_host,
+        port=settings.redis_port,
+        password=settings.redis_password or None,
+        db=settings.redis_db,
+        decode_responses=decode_responses,
+    )
+
+
+def get_redis_client(*, decode_responses: bool = True) -> redis.Redis:
+    """Return a synchronous Redis client backed by a shared connection pool.
+
+    Args:
+        decode_responses: ``True`` (default) for ``str`` responses used by
+            application data and event publishing; ``False`` for ``bytes``
+            responses required by RQ.
+
+    Returns:
+        A ``redis.Redis`` client sharing the appropriate process-wide pool.
+    """
+    global _decoded_pool, _raw_pool  # noqa: PLW0603 - module-level pool cache
+
+    if decode_responses:
+        if _decoded_pool is None:
+            _decoded_pool = _build_pool(decode_responses=True)
+        return redis.Redis(connection_pool=_decoded_pool)
+
+    if _raw_pool is None:
+        _raw_pool = _build_pool(decode_responses=False)
+    return redis.Redis(connection_pool=_raw_pool)
+
+
+def close_redis_pools() -> None:
+    """Disconnect and reset the shared Redis pools.
+
+    Intended to be called from the FastAPI shutdown lifespan so connections
+    are released gracefully. Safe to call when no pools were created.
+    """
+    global _decoded_pool, _raw_pool  # noqa: PLW0603 - module-level pool cache
+
+    for pool in (_decoded_pool, _raw_pool):
+        if pool is not None:
+            pool.disconnect()
+
+    if _decoded_pool is not None or _raw_pool is not None:
+        logger.info("Closed shared Redis connection pools")
+
+    _decoded_pool = None
+    _raw_pool = None
+
+
+__all__ = ["close_redis_pools", "get_redis_client"]

--- a/src/rag_processor/core/redis.py
+++ b/src/rag_processor/core/redis.py
@@ -23,6 +23,8 @@ thread via ``asyncio.to_thread``.
 
 from __future__ import annotations
 
+import threading
+
 import redis
 
 from rag_processor.core.config import settings
@@ -33,6 +35,11 @@ logger = get_logger(__name__)
 # Process-wide connection pools, created lazily on first use.
 _decoded_pool: redis.ConnectionPool | None = None
 _raw_pool: redis.ConnectionPool | None = None
+
+# Guards lazy pool construction/reset. get_redis_client is called from worker
+# threads via asyncio.to_thread, so without this lock two threads racing on
+# first use could build two pools (one of which leaks sockets until GC).
+_pool_lock = threading.Lock()
 
 
 def _build_pool(*, decode_responses: bool) -> redis.ConnectionPool:
@@ -68,11 +75,16 @@ def get_redis_client(*, decode_responses: bool = True) -> redis.Redis:
 
     if decode_responses:
         if _decoded_pool is None:
-            _decoded_pool = _build_pool(decode_responses=True)
+            with _pool_lock:
+                # Re-check under the lock so only one thread builds the pool.
+                if _decoded_pool is None:
+                    _decoded_pool = _build_pool(decode_responses=True)
         return redis.Redis(connection_pool=_decoded_pool)
 
     if _raw_pool is None:
-        _raw_pool = _build_pool(decode_responses=False)
+        with _pool_lock:
+            if _raw_pool is None:
+                _raw_pool = _build_pool(decode_responses=False)
     return redis.Redis(connection_pool=_raw_pool)
 
 
@@ -84,15 +96,16 @@ def close_redis_pools() -> None:
     """
     global _decoded_pool, _raw_pool  # noqa: PLW0603 - module-level pool cache
 
-    for pool in (_decoded_pool, _raw_pool):
-        if pool is not None:
-            pool.disconnect()
+    with _pool_lock:
+        for pool in (_decoded_pool, _raw_pool):
+            if pool is not None:
+                pool.disconnect()
 
-    if _decoded_pool is not None or _raw_pool is not None:
-        logger.info("Closed shared Redis connection pools")
+        if _decoded_pool is not None or _raw_pool is not None:
+            logger.info("Closed shared Redis connection pools")
 
-    _decoded_pool = None
-    _raw_pool = None
+        _decoded_pool = None
+        _raw_pool = None
 
 
 __all__ = ["close_redis_pools", "get_redis_client"]

--- a/src/rag_processor/main.py
+++ b/src/rag_processor/main.py
@@ -30,6 +30,7 @@ from rag_processor.middleware import (
     CorrelationMiddleware,
     SecurityConfig,
     add_security_middleware,
+    get_correlation_id,
 )
 from rag_processor.utils.logging import get_logger, setup_logging
 from rag_processor.websocket.router import router as websocket_router
@@ -45,6 +46,10 @@ setup_logging(
 )
 
 logger = get_logger(__name__)
+
+# Statuses at or above this value are server-class errors whose ``details``
+# must be withheld from clients to avoid leaking internal infrastructure.
+_SERVER_ERROR_THRESHOLD = 500
 
 
 @asynccontextmanager
@@ -150,7 +155,38 @@ async def handle_project_error(
     Returns:
         A JSON response with the mapped status code and the exception payload.
     """
-    return JSONResponse(status_code=http_status_for(exc), content=exc.to_dict())
+    status = http_status_for(exc)
+    correlation_id = get_correlation_id()
+
+    # Server-class failures (5xx) must never leak internal infrastructure
+    # context (e.g. service_name, status_code, database operation/table held in
+    # ``details``) to clients. Return only the safe error/message/code fields
+    # and keep the full context in server-side logs for troubleshooting.
+    if status >= _SERVER_ERROR_THRESHOLD:
+        logger.error(
+            "Request failed with server error",
+            correlation_id=correlation_id,
+            status=status,
+            error=exc.__class__.__name__,
+            error_code=exc.error_code,
+            details=exc.details,
+        )
+        payload: dict[str, object] = {
+            "error": exc.__class__.__name__,
+            "message": exc.message,
+        }
+        if exc.error_code:
+            payload["code"] = exc.error_code
+        return JSONResponse(status_code=status, content=payload)
+
+    logger.warning(
+        "Request failed with client error",
+        correlation_id=correlation_id,
+        status=status,
+        error=exc.__class__.__name__,
+        error_code=exc.error_code,
+    )
+    return JSONResponse(status_code=status, content=exc.to_dict())
 
 
 @app.get(

--- a/src/rag_processor/main.py
+++ b/src/rag_processor/main.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from rag_processor import __version__
 from rag_processor.api import health_router
@@ -23,6 +24,8 @@ from rag_processor.api.ingest import router as ingest_router
 from rag_processor.api.user import router as user_router
 from rag_processor.auth.cloudflare import CloudflareAuthMiddleware
 from rag_processor.core.config import settings
+from rag_processor.core.exceptions import ProjectBaseError, http_status_for
+from rag_processor.core.redis import close_redis_pools
 from rag_processor.middleware import (
     CorrelationMiddleware,
     SecurityConfig,
@@ -66,6 +69,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
     # Shutdown
     logger.info("Shutting down RAG Processor Gateway")
+    close_redis_pools()
 
 
 # Create FastAPI application
@@ -125,6 +129,28 @@ app.include_router(user_router, prefix="/api/v1")
 app.include_router(ingest_router, prefix="/api/v1")
 app.include_router(batch_router, prefix="/api/v1")
 app.include_router(websocket_router)
+
+
+@app.exception_handler(ProjectBaseError)
+async def handle_project_error(
+    request: Request,  # noqa: ARG001 - required by FastAPI handler signature
+    exc: ProjectBaseError,
+) -> JSONResponse:
+    """Translate domain exceptions into consistent JSON error responses.
+
+    Wires the centralized exception hierarchy into the app so any
+    ``ProjectBaseError`` raised by a handler or dependency is rendered with the
+    appropriate HTTP status and a structured body, instead of surfacing as a
+    generic 500.
+
+    Args:
+        request: The incoming request (unused).
+        exc: The raised project exception.
+
+    Returns:
+        A JSON response with the mapped status code and the exception payload.
+    """
+    return JSONResponse(status_code=http_status_for(exc), content=exc.to_dict())
 
 
 @app.get(

--- a/src/rag_processor/models/batch.py
+++ b/src/rag_processor/models/batch.py
@@ -11,25 +11,9 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from rag_processor.utils.time_utils import parse_iso_datetime as _parse_iso_datetime
+
 UTC = timezone.utc  # noqa: UP017
-
-
-def _parse_iso_datetime(value: str) -> datetime:
-    """Parse ISO format datetime string with Python 3.10 compatibility.
-
-    Python 3.10's fromisoformat() doesn't support 'Z' suffix for UTC.
-    This function handles both 'Z' suffix and '+00:00' format.
-
-    Args:
-        value: ISO format datetime string.
-
-    Returns:
-        Parsed datetime object.
-    """
-    # Replace Z suffix with +00:00 for Python 3.10 compatibility
-    if value.endswith("Z"):
-        value = value[:-1] + "+00:00"
-    return datetime.fromisoformat(value)
 
 
 class BatchStatus(StrEnum):

--- a/src/rag_processor/models/job.py
+++ b/src/rag_processor/models/job.py
@@ -11,25 +11,9 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from rag_processor.utils.time_utils import parse_iso_datetime as _parse_iso_datetime
+
 UTC = timezone.utc  # noqa: UP017
-
-
-def _parse_iso_datetime(value: str) -> datetime:
-    """Parse ISO format datetime string with Python 3.10 compatibility.
-
-    Python 3.10's fromisoformat() doesn't support 'Z' suffix for UTC.
-    This function handles both 'Z' suffix and '+00:00' format.
-
-    Args:
-        value: ISO format datetime string.
-
-    Returns:
-        Parsed datetime object.
-    """
-    # Replace Z suffix with +00:00 for Python 3.10 compatibility
-    if value.endswith("Z"):
-        value = value[:-1] + "+00:00"
-    return datetime.fromisoformat(value)
 
 
 class JobStatus(StrEnum):

--- a/src/rag_processor/queue/client.py
+++ b/src/rag_processor/queue/client.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 import redis
 from rq import Queue
 
-from rag_processor.core.config import settings
+from rag_processor.core.redis import get_redis_client
 from rag_processor.models.job import Priority
 from rag_processor.utils.logging import get_logger
 
@@ -52,12 +52,8 @@ class QueueClient:
         if redis_client is not None:
             self._redis = redis_client
         else:
-            self._redis = redis.Redis(
-                host=settings.redis_host,
-                port=settings.redis_port,
-                password=settings.redis_password or None,
-                db=settings.redis_db,
-            )
+            # RQ requires raw (bytes) responses; use the shared raw pool.
+            self._redis = get_redis_client(decode_responses=False)
 
         # Create priority queues
         self._queues = {

--- a/src/rag_processor/queue/jobs.py
+++ b/src/rag_processor/queue/jobs.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 from uuid import UUID  # noqa: TC003 - Used at runtime in function signatures
 
 from rag_processor.models.batch import Batch, BatchStatus
@@ -15,9 +16,15 @@ from rag_processor.queue.client import get_queue_client
 from rag_processor.queue.redis_store import get_redis_store
 from rag_processor.utils.logging import get_logger
 
+if TYPE_CHECKING:
+    from rag_processor.queue.redis_store import RedisStore
+
 UTC = timezone.utc  # noqa: UP017
 
 logger = get_logger(__name__)
+
+# Default per-job processing timeout (seconds) applied when enqueuing to RQ.
+JOB_TIMEOUT_SECONDS = 600
 
 
 def enqueue_job(job: Job) -> str:
@@ -41,7 +48,7 @@ def enqueue_job(job: Job) -> str:
         process_job_task,
         str(job.job_id),
         priority=job.priority,
-        job_timeout=600,  # 10 minutes
+        job_timeout=JOB_TIMEOUT_SECONDS,
     )
 
     logger.info(
@@ -56,9 +63,13 @@ def enqueue_job(job: Job) -> str:
 
 
 def enqueue_batch_jobs(batch: Batch, jobs: list[Job]) -> list[str]:
-    """Submit a batch of jobs to the queue.
+    """Submit a batch of jobs to the queue with all-or-nothing semantics.
 
-    Saves batch and all jobs to Redis and enqueues them.
+    Saves the batch and each job to Redis and enqueues them to RQ, tracking the
+    RQ jobs as they are created. If any enqueue fails partway through, every
+    already-enqueued RQ job is cancelled and the batch's Redis state is removed
+    before re-raising, so a caller never observes a partially-enqueued batch
+    (which would otherwise leave orphaned RQ jobs whose metadata was deleted).
 
     Args:
         batch: Parent batch.
@@ -66,17 +77,37 @@ def enqueue_batch_jobs(batch: Batch, jobs: list[Job]) -> list[str]:
 
     Returns:
         List of RQ job IDs.
+
+    Raises:
+        Exception: Re-raises any enqueue failure after rolling back.
     """
     store = get_redis_store()
+    client = get_queue_client()
 
     # Save batch first
     store.save_batch(batch)
 
-    # Enqueue all jobs
-    rq_job_ids = []
-    for job in jobs:
-        rq_job_id = enqueue_job(job)
-        rq_job_ids.append(rq_job_id)
+    enqueued_rq_jobs: list[Any] = []
+    try:
+        for job in jobs:
+            # Persist job metadata, then enqueue. Tracking the RQ job lets us
+            # cancel it during rollback if a later job fails to enqueue.
+            store.save_job(job)
+            rq_job = client.enqueue(
+                process_job_task,
+                str(job.job_id),
+                priority=job.priority,
+                job_timeout=JOB_TIMEOUT_SECONDS,
+            )
+            enqueued_rq_jobs.append(rq_job)
+    except Exception:
+        logger.exception(
+            "Failed to enqueue batch; rolling back",
+            batch_id=str(batch.batch_id),
+            enqueued=len(enqueued_rq_jobs),
+        )
+        _rollback_enqueued_batch(store, batch, enqueued_rq_jobs)
+        raise
 
     logger.info(
         "Batch jobs enqueued",
@@ -84,7 +115,34 @@ def enqueue_batch_jobs(batch: Batch, jobs: list[Job]) -> list[str]:
         total_jobs=len(jobs),
     )
 
-    return rq_job_ids
+    return [rq_job.id for rq_job in enqueued_rq_jobs]
+
+
+def _rollback_enqueued_batch(
+    store: RedisStore,
+    batch: Batch,
+    enqueued_rq_jobs: list[Any],
+) -> None:
+    """Cancel already-enqueued RQ jobs and delete the batch's Redis state.
+
+    Best-effort: individual cancellation failures are logged but do not prevent
+    the remaining cleanup, since this runs while handling an enqueue failure.
+
+    Args:
+        store: Redis store used to delete the batch and its jobs.
+        batch: The batch being rolled back.
+        enqueued_rq_jobs: RQ jobs that were successfully enqueued before failure.
+    """
+    for rq_job in enqueued_rq_jobs:
+        try:
+            rq_job.cancel()
+            rq_job.delete()
+        except Exception:  # noqa: BLE001 - best-effort cleanup during rollback
+            logger.warning(
+                "Failed to cancel enqueued RQ job during rollback",
+                rq_job_id=getattr(rq_job, "id", None),
+            )
+    store.delete_batch(batch.batch_id)
 
 
 def get_job_status(job_id: UUID | str) -> Job | None:

--- a/src/rag_processor/queue/jobs.py
+++ b/src/rag_processor/queue/jobs.py
@@ -300,6 +300,10 @@ def process_job_task(job_id: str) -> dict[str, str]:
     # A narrow TOCTOU window remains between this check and the writes below;
     # it is acceptable given enqueue is gated behind enqueue_enabled and the
     # rollback path is itself an error path.
+    # FIXME(reconciliation): there is currently no automated reconciler for jobs
+    # orphaned by this race or left in PROCESSING when failure recording fails
+    # (see the best-effort handler below). Recovery is manual until a periodic
+    # sweep (e.g. reconcile_orphaned_jobs) is added alongside the rollback path.
     if store.get_batch(job.batch_id) is None:
         logger.warning(
             "Parent batch missing; skipping job to avoid orphan",

--- a/src/rag_processor/queue/jobs.py
+++ b/src/rag_processor/queue/jobs.py
@@ -128,6 +128,12 @@ def _rollback_enqueued_batch(
     Best-effort: individual cancellation failures are logged but do not prevent
     the remaining cleanup, since this runs while handling an enqueue failure.
 
+    Note: ``rq_job.cancel()`` only removes a job that is still *queued*; it
+    cannot stop one a worker has already started. A worker mid-run could write
+    job status after ``delete_batch`` here, recreating an orphaned ``job:{id}``
+    hash. ``process_job_task`` guards against this by bailing if its parent
+    batch has disappeared, which closes all but a narrow TOCTOU window.
+
     Args:
         store: Redis store used to delete the batch and its jobs.
         batch: The batch being rolled back.
@@ -287,6 +293,25 @@ def process_job_task(job_id: str) -> dict[str, str]:
         pipeline=job.routed_to.value,
     )
 
+    # Guard against the enqueue-rollback orphan race: if the parent batch has
+    # been deleted (e.g. _rollback_enqueued_batch ran after this job was already
+    # picked up by a worker), do not write any job status — doing so would
+    # recreate an orphaned job:{id} hash with no parent batch. Bail cleanly.
+    # A narrow TOCTOU window remains between this check and the writes below;
+    # it is acceptable given enqueue is gated behind enqueue_enabled and the
+    # rollback path is itself an error path.
+    if store.get_batch(job.batch_id) is None:
+        logger.warning(
+            "Parent batch missing; skipping job to avoid orphan",
+            job_id=job_id,
+            batch_id=str(job.batch_id),
+        )
+        return {
+            "status": "skipped",
+            "job_id": job_id,
+            "error": "Parent batch not found",
+        }
+
     # Mark job as processing
     store.update_job_status(
         job_id,
@@ -313,13 +338,25 @@ def process_job_task(job_id: str) -> dict[str, str]:
             job_id=job_id,
             batch_id=str(job.batch_id),
         )
-        store.update_job_status(
-            job_id,
-            status=JobStatus.FAILED.value,
-            error_message=str(exc),
-            completed_at=datetime.now(tz=UTC).isoformat(),
-        )
-        update_batch_progress(job.batch_id)
+        # Best-effort failure recording. If the pipeline failed because Redis
+        # itself is down (a likely correlated cause), these writes can raise
+        # too; swallow so the worker exits cleanly. RQ will mark the task
+        # failed, and a later reconciliation/retry can recover the stuck job —
+        # better than crashing the worker here.
+        try:
+            store.update_job_status(
+                job_id,
+                status=JobStatus.FAILED.value,
+                error_message=str(exc),
+                completed_at=datetime.now(tz=UTC).isoformat(),
+            )
+            update_batch_progress(job.batch_id)
+        except Exception:
+            logger.exception(
+                "Failed to record job failure (Redis may be unavailable)",
+                job_id=job_id,
+                batch_id=str(job.batch_id),
+            )
         return {"status": "failed", "job_id": job_id, "error": str(exc)}
 
     # Mark job as completed

--- a/src/rag_processor/queue/jobs.py
+++ b/src/rag_processor/queue/jobs.py
@@ -5,6 +5,7 @@ Functions for enqueuing jobs and checking their status.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from uuid import UUID  # noqa: TC003 - Used at runtime in function signatures
 
@@ -118,6 +119,39 @@ def get_batch_status(batch_id: UUID | str) -> tuple[Batch | None, list[Job]]:
     return batch, jobs
 
 
+async def get_job_status_async(job_id: UUID | str) -> Job | None:
+    """Async, non-blocking wrapper around :func:`get_job_status`.
+
+    The underlying store uses a synchronous Redis client (shared with the RQ
+    worker), so the blocking call is offloaded to a worker thread to avoid
+    stalling the event loop in async HTTP/WebSocket handlers.
+
+    Args:
+        job_id: Job identifier.
+
+    Returns:
+        Job if found, None otherwise.
+    """
+    return await asyncio.to_thread(get_job_status, job_id)
+
+
+async def get_batch_status_async(
+    batch_id: UUID | str,
+) -> tuple[Batch | None, list[Job]]:
+    """Async, non-blocking wrapper around :func:`get_batch_status`.
+
+    Offloads the synchronous Redis reads to a worker thread so async handlers
+    do not block the event loop.
+
+    Args:
+        batch_id: Batch identifier.
+
+    Returns:
+        Tuple of (Batch, list of Jobs). Batch is None if not found.
+    """
+    return await asyncio.to_thread(get_batch_status, batch_id)
+
+
 def update_batch_progress(batch_id: UUID | str) -> None:
     """Update batch progress based on job statuses.
 
@@ -205,12 +239,30 @@ def process_job_task(job_id: str) -> dict[str, str]:
     # Update batch progress
     update_batch_progress(job.batch_id)
 
-    # TODO: Actually call the pipeline adapter here (Sprint 1.15)
-    # For now, we just simulate success
-    # In production, this would:
-    # 1. Call the appropriate PipelineAdapter based on job.routed_to
-    # 2. Poll for completion
-    # 3. Handle retries on failure
+    try:
+        # TODO: Actually call the pipeline adapter here (Sprint 1.15)
+        # For now, we just simulate success
+        # In production, this would:
+        # 1. Call the appropriate PipelineAdapter based on job.routed_to
+        # 2. Poll for completion
+        _run_pipeline(job)
+    except Exception as exc:
+        # Worker boundary: any pipeline failure must be recorded against the
+        # job and reflected in the batch rather than crashing the worker and
+        # leaving the batch stuck in PROCESSING forever.
+        logger.exception(
+            "Job processing failed",
+            job_id=job_id,
+            batch_id=str(job.batch_id),
+        )
+        store.update_job_status(
+            job_id,
+            status=JobStatus.FAILED.value,
+            error_message=str(exc),
+            completed_at=datetime.now(tz=UTC).isoformat(),
+        )
+        update_batch_progress(job.batch_id)
+        return {"status": "failed", "job_id": job_id, "error": str(exc)}
 
     # Mark job as completed
     store.update_job_status(
@@ -229,3 +281,22 @@ def process_job_task(job_id: str) -> dict[str, str]:
     )
 
     return {"status": "completed", "job_id": job_id}
+
+
+def _run_pipeline(job: Job) -> None:
+    """Execute the processing pipeline for a job.
+
+    Placeholder for the pipeline adapter call (Sprint 1.15). Isolated into its
+    own function so the failure-handling boundary in ``process_job_task`` has a
+    single, mockable seam and real pipeline errors are captured per-job.
+
+    Args:
+        job: The job to process.
+    """
+    # Intentionally a no-op until the pipeline adapter lands. The job is logged
+    # so the seam is observable and the argument is meaningfully used.
+    logger.debug(
+        "Running pipeline (no-op placeholder)",
+        job_id=str(job.job_id),
+        pipeline=job.routed_to.value,
+    )

--- a/src/rag_processor/queue/redis_store.py
+++ b/src/rag_processor/queue/redis_store.py
@@ -11,7 +11,7 @@ from uuid import UUID  # noqa: TC003 - Used at runtime in function signatures
 
 import redis
 
-from rag_processor.core.config import settings
+from rag_processor.core.redis import get_redis_client
 from rag_processor.models.batch import Batch
 from rag_processor.models.job import Job
 from rag_processor.utils.logging import get_logger
@@ -47,13 +47,8 @@ class RedisStore:
         if redis_client is not None:
             self._redis = redis_client
         else:
-            self._redis = redis.Redis(
-                host=settings.redis_host,
-                port=settings.redis_port,
-                password=settings.redis_password or None,
-                db=settings.redis_db,
-                decode_responses=True,
-            )
+            # Decoded (str) client from the shared pool; see core/redis.py.
+            self._redis = get_redis_client(decode_responses=True)
 
     def save_batch(self, batch: Batch) -> None:
         """Save a batch to Redis.

--- a/src/rag_processor/websocket/events.py
+++ b/src/rag_processor/websocket/events.py
@@ -8,14 +8,16 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
-import redis
 from pydantic import BaseModel, Field
 
-from rag_processor.core.config import settings
+from rag_processor.core.redis import get_redis_client as _get_shared_redis_client
 from rag_processor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    import redis
 
 UTC = timezone.utc  # noqa: UP017
 
@@ -92,16 +94,14 @@ class BatchEvent(BaseModel):
 def get_redis_client() -> redis.Redis:
     """Get a Redis client for event publishing.
 
+    Returns a decoded (str) client backed by the shared connection pool in
+    ``core/redis.py`` so event publishing reuses the same Redis connections as
+    the rest of the application.
+
     Returns:
         Redis client instance.
     """
-    return redis.Redis(
-        host=settings.redis_host,
-        port=settings.redis_port,
-        password=settings.redis_password or None,
-        db=settings.redis_db,
-        decode_responses=True,
-    )
+    return _get_shared_redis_client(decode_responses=True)
 
 
 def publish_event(event: BatchEvent, redis_client: redis.Redis | None = None) -> None:

--- a/src/rag_processor/websocket/events.py
+++ b/src/rag_processor/websocket/events.py
@@ -5,6 +5,7 @@ Defines event structure and functions for publishing events to Redis.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from enum import StrEnum
@@ -169,6 +170,26 @@ def get_event_history(
             logger.warning("Failed to parse event from history", raw_event=event_str)
 
     return events
+
+
+async def get_event_history_async(
+    batch_id: UUID | str,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Async, non-blocking wrapper around :func:`get_event_history`.
+
+    Offloads the synchronous Redis reads to a worker thread so async WebSocket
+    handlers do not block the event loop, mirroring the ``*_async`` wrappers in
+    ``rag_processor.queue.jobs``.
+
+    Args:
+        batch_id: Batch identifier.
+        limit: Maximum events to return.
+
+    Returns:
+        List of events (oldest first).
+    """
+    return await asyncio.to_thread(get_event_history, batch_id, limit=limit)
 
 
 def create_job_event(

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -77,7 +77,8 @@ async def _replay_events(
         batch_id: Batch identifier.
         last_event_id: Last event ID received by client.
     """
-    history = get_event_history(batch_id)
+    # Offload the synchronous Redis read off the event loop.
+    history = await asyncio.to_thread(get_event_history, batch_id)
     found_last = False
 
     for event in history:
@@ -157,7 +158,7 @@ async def websocket_batch_status(
 
     # Verify batch exists and the caller owns it. Treat "not found" and
     # "not authorized" identically to avoid leaking batch IDs.
-    batch, _ = get_batch_status(batch_id)
+    batch, _ = await asyncio.to_thread(get_batch_status, batch_id)
     if batch is None:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, status
 from rag_processor.auth.cloudflare import verify_cloudflare_token
 from rag_processor.auth.dependencies import batch_is_owned_by
 from rag_processor.core.config import settings
-from rag_processor.queue.jobs import get_batch_status
+from rag_processor.queue.jobs import get_batch_status_async
 from rag_processor.utils.logging import get_logger
 from rag_processor.websocket.connection_manager import connection_manager
 from rag_processor.websocket.events import get_event_history
@@ -158,7 +158,7 @@ async def websocket_batch_status(
 
     # Verify batch exists and the caller owns it. Treat "not found" and
     # "not authorized" identically to avoid leaking batch IDs.
-    batch, _ = await asyncio.to_thread(get_batch_status, batch_id)
+    batch, _ = await get_batch_status_async(batch_id)
     if batch is None:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return

--- a/src/rag_processor/websocket/router.py
+++ b/src/rag_processor/websocket/router.py
@@ -17,7 +17,7 @@ from rag_processor.core.config import settings
 from rag_processor.queue.jobs import get_batch_status_async
 from rag_processor.utils.logging import get_logger
 from rag_processor.websocket.connection_manager import connection_manager
-from rag_processor.websocket.events import get_event_history
+from rag_processor.websocket.events import get_event_history_async
 
 logger = get_logger(__name__)
 
@@ -77,8 +77,9 @@ async def _replay_events(
         batch_id: Batch identifier.
         last_event_id: Last event ID received by client.
     """
-    # Offload the synchronous Redis read off the event loop.
-    history = await asyncio.to_thread(get_event_history, batch_id)
+    # Non-blocking read via the shared async wrapper (offloads the sync Redis
+    # call off the event loop); see websocket.events.
+    history = await get_event_history_async(batch_id)
     found_last = False
 
     for event in history:

--- a/tests/integration/test_e2e_flow.py
+++ b/tests/integration/test_e2e_flow.py
@@ -52,6 +52,8 @@ def mock_ingest_settings(temp_upload_dir: str) -> Generator[None, None, None]:
             "text/plain",
         ]
         mock.upload_dir = temp_upload_dir
+        # No background enqueue in these tests (no Redis/worker available).
+        mock.enqueue_enabled = False
         yield mock
 
 

--- a/tests/unit/test_auth_cloudflare.py
+++ b/tests/unit/test_auth_cloudflare.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from rag_processor.auth.cloudflare import (
     _jwks_cache,
     _JWKSCache,
+    _parse_jwks_payload,
     clear_jwks_cache,
     verify_cloudflare_token,
 )
@@ -229,3 +230,57 @@ class TestVerifyCloudflareToken:
         assert result["email"] == "cf@example.com"
         mock_client.get.assert_awaited_once()
         assert _jwks_cache.is_valid()
+
+    @pytest.mark.anyio
+    async def test_key_rotation_forces_refresh_and_recovers(self) -> None:
+        """A token signed with a rotated key recovers via a forced refresh.
+
+        The cache is valid but lacks the token's signing key (Cloudflare
+        rotated keys within the TTL). Resolution must force-refresh the JWKS
+        once and succeed rather than rejecting a valid token.
+        """
+        # Valid cache that does not contain the token's signing key.
+        _jwks_cache.update({"keys": []})
+        assert _jwks_cache.is_valid()
+        token = _make_token()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"keys": [PUBLIC_JWK]}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "rag_processor.auth.cloudflare.httpx.AsyncClient", return_value=mock_client
+        ):
+            result = await verify_cloudflare_token(token)
+
+        assert result["email"] == "cf@example.com"
+        # The forced refresh must have hit Cloudflare exactly once.
+        mock_client.get.assert_awaited_once()
+
+
+class TestParseJWKSPayload:
+    """The JWKS payload is validated at the trust boundary before caching."""
+
+    def test_valid_payload_is_normalized(self) -> None:
+        jwks, keys_count = _parse_jwks_payload({"keys": [PUBLIC_JWK]})
+        assert jwks["keys"] == [PUBLIC_JWK]
+        assert keys_count == 1
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "not-a-dict",
+            {"keys": "not-a-list"},
+            {"keys": ["not-a-dict"]},
+            {"keys": [{"kty": "RSA"}]},  # missing string "kid"
+            {"keys": [{"kid": 123}]},  # non-string "kid"
+        ],
+    )
+    def test_malformed_payload_raises(self, payload: object) -> None:
+        with pytest.raises(jwt.InvalidTokenError):
+            _parse_jwks_payload(payload)

--- a/tests/unit/test_auth_cloudflare.py
+++ b/tests/unit/test_auth_cloudflare.py
@@ -172,6 +172,19 @@ class TestVerifyCloudflareToken:
             await verify_cloudflare_token(token)
 
     @pytest.mark.anyio
+    async def test_token_within_leeway_is_accepted(self) -> None:
+        """Regression: WS path now shares the HTTP middleware's clock-skew leeway.
+
+        A token expired by less than the leeway must be accepted, matching the
+        middleware (previously verify_cloudflare_token used no leeway and would
+        reject it).
+        """
+        _jwks_cache.update({"keys": [PUBLIC_JWK]})
+        token = _make_token(exp_delta=timedelta(seconds=-3))
+        result = await verify_cloudflare_token(token)
+        assert result["email"] == "cf@example.com"
+
+    @pytest.mark.anyio
     async def test_missing_kid_raises(self) -> None:
         _jwks_cache.update({"keys": [PUBLIC_JWK]})
         token = _make_token(include_kid=False)

--- a/tests/unit/test_batch_authz.py
+++ b/tests/unit/test_batch_authz.py
@@ -4,13 +4,13 @@ These tests exercise the ownership check added in
 src/rag_processor/api/batch.py so SonarCloud / Codecov see the new branches as
 covered. We don't use the running TestClient transport here because that
 requires booting the auth middleware and Redis; instead we drive the handler
-functions directly with mocks for `get_batch_status` / `get_job_status`.
+functions directly with mocks for `get_batch_status_async` / `get_job_status_async`.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -130,7 +130,8 @@ class TestGetBatchAuthz:
     async def test_owner_can_read_batch(self):
         batch = _batch()
         with patch(
-            "rag_processor.api.batch.get_batch_status",
+            "rag_processor.api.batch.get_batch_status_async",
+            new_callable=AsyncMock,
             return_value=(batch, []),
         ):
             resp = await get_batch(batch.batch_id, user=_user())
@@ -141,7 +142,8 @@ class TestGetBatchAuthz:
         batch = _batch(created_by_user_id="other-user", created_by_email="other@x")
         with (
             patch(
-                "rag_processor.api.batch.get_batch_status",
+                "rag_processor.api.batch.get_batch_status_async",
+                new_callable=AsyncMock,
                 return_value=(batch, []),
             ),
             pytest.raises(HTTPException) as exc,
@@ -154,7 +156,8 @@ class TestGetBatchAuthz:
     async def test_missing_batch_returns_404(self):
         with (
             patch(
-                "rag_processor.api.batch.get_batch_status",
+                "rag_processor.api.batch.get_batch_status_async",
+                new_callable=AsyncMock,
                 return_value=(None, []),
             ),
             pytest.raises(HTTPException) as exc,
@@ -171,9 +174,14 @@ class TestGetJobAuthz:
         batch = _batch()
         job = _job(batch.batch_id)
         with (
-            patch("rag_processor.api.batch.get_job_status", return_value=job),
             patch(
-                "rag_processor.api.batch.get_batch_status",
+                "rag_processor.api.batch.get_job_status_async",
+                new_callable=AsyncMock,
+                return_value=job,
+            ),
+            patch(
+                "rag_processor.api.batch.get_batch_status_async",
+                new_callable=AsyncMock,
                 return_value=(batch, [job]),
             ),
         ):
@@ -185,9 +193,14 @@ class TestGetJobAuthz:
         batch = _batch(created_by_user_id="other-user", created_by_email="other@x")
         job = _job(batch.batch_id)
         with (
-            patch("rag_processor.api.batch.get_job_status", return_value=job),
             patch(
-                "rag_processor.api.batch.get_batch_status",
+                "rag_processor.api.batch.get_job_status_async",
+                new_callable=AsyncMock,
+                return_value=job,
+            ),
+            patch(
+                "rag_processor.api.batch.get_batch_status_async",
+                new_callable=AsyncMock,
                 return_value=(batch, [job]),
             ),
             pytest.raises(HTTPException) as exc,
@@ -198,7 +211,11 @@ class TestGetJobAuthz:
     @pytest.mark.asyncio
     async def test_missing_job_returns_404(self):
         with (
-            patch("rag_processor.api.batch.get_job_status", return_value=None),
+            patch(
+                "rag_processor.api.batch.get_job_status_async",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
             pytest.raises(HTTPException) as exc,
         ):
             await get_job(uuid4(), user=_user())
@@ -209,9 +226,14 @@ class TestGetJobAuthz:
         # Defensive: a job whose batch row has been deleted must not be readable.
         job = _job(uuid4())
         with (
-            patch("rag_processor.api.batch.get_job_status", return_value=job),
             patch(
-                "rag_processor.api.batch.get_batch_status",
+                "rag_processor.api.batch.get_job_status_async",
+                new_callable=AsyncMock,
+                return_value=job,
+            ),
+            patch(
+                "rag_processor.api.batch.get_batch_status_async",
+                new_callable=AsyncMock,
                 return_value=(None, []),
             ),
             pytest.raises(HTTPException) as exc,

--- a/tests/unit/test_core_redis.py
+++ b/tests/unit/test_core_redis.py
@@ -1,0 +1,48 @@
+"""Tests for the centralized Redis client factory (core/redis.py)."""
+
+from __future__ import annotations
+
+import redis
+
+from rag_processor.core import redis as core_redis
+
+
+class TestGetRedisClient:
+    """Tests for get_redis_client and shared connection pools."""
+
+    def teardown_method(self) -> None:
+        """Reset shared pools so tests don't leak state."""
+        core_redis.close_redis_pools()
+
+    def test_returns_redis_client(self) -> None:
+        client = core_redis.get_redis_client()
+        assert isinstance(client, redis.Redis)
+
+    def test_decoded_clients_share_one_pool(self) -> None:
+        c1 = core_redis.get_redis_client(decode_responses=True)
+        c2 = core_redis.get_redis_client(decode_responses=True)
+        # Same process-wide pool is reused rather than re-created per client.
+        assert c1.connection_pool is c2.connection_pool
+
+    def test_decoded_and_raw_use_distinct_pools(self) -> None:
+        decoded = core_redis.get_redis_client(decode_responses=True)
+        raw = core_redis.get_redis_client(decode_responses=False)
+        assert decoded.connection_pool is not raw.connection_pool
+
+    def test_decode_responses_flag_propagates_to_pool(self) -> None:
+        decoded = core_redis.get_redis_client(decode_responses=True)
+        raw = core_redis.get_redis_client(decode_responses=False)
+        assert decoded.connection_pool.connection_kwargs["decode_responses"] is True
+        assert raw.connection_pool.connection_kwargs["decode_responses"] is False
+
+    def test_close_redis_pools_resets_pools(self) -> None:
+        first = core_redis.get_redis_client(decode_responses=True)
+        core_redis.close_redis_pools()
+        second = core_redis.get_redis_client(decode_responses=True)
+        # After close a fresh pool is built on next use.
+        assert first.connection_pool is not second.connection_pool
+
+    def test_close_redis_pools_is_safe_when_unused(self) -> None:
+        core_redis.close_redis_pools()
+        # No pools created yet; calling again must not raise.
+        core_redis.close_redis_pools()

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,0 +1,74 @@
+"""Tests for the domain-exception HTTP mapping and FastAPI handler wiring."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from rag_processor.core.exceptions import (
+    APIError,
+    AuthenticationError,
+    AuthorizationError,
+    BusinessLogicError,
+    ConfigurationError,
+    DatabaseError,
+    ExternalServiceError,
+    ProjectBaseError,
+    ResourceNotFoundError,
+    ValidationError,
+    http_status_for,
+)
+from rag_processor.main import handle_project_error
+
+
+class TestHttpStatusFor:
+    """Status-code mapping for each exception type."""
+
+    @pytest.mark.parametrize(
+        ("exc", "expected"),
+        [
+            (DatabaseError("db"), 503),
+            (APIError("api"), 502),
+            (ExternalServiceError("svc"), 502),
+            (AuthenticationError(), 401),
+            (AuthorizationError(), 403),
+            (ResourceNotFoundError("missing"), 404),
+            (ValidationError("bad"), 400),
+            (BusinessLogicError("rule"), 409),
+            (ConfigurationError("cfg"), 500),
+            (ProjectBaseError("base"), 500),
+        ],
+    )
+    def test_status_mapping(self, exc: ProjectBaseError, expected: int) -> None:
+        assert http_status_for(exc) == expected
+
+    def test_database_error_checked_before_external_service(self) -> None:
+        # DatabaseError subclasses ExternalServiceError; must map to 503 not 502.
+        assert http_status_for(DatabaseError("db")) == 503
+
+
+class TestExceptionHandlerWiring:
+    """The handler must render domain exceptions raised inside endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_handler_returns_mapped_status_and_body(self) -> None:
+        exc = ResourceNotFoundError("nope", resource_type="Batch")
+        response = await handle_project_error(None, exc)  # type: ignore[arg-type]
+        assert response.status_code == 404
+
+    def test_app_translates_domain_exception(self) -> None:
+        app = FastAPI()
+        app.add_exception_handler(ProjectBaseError, handle_project_error)
+
+        @app.get("/boom")
+        async def boom() -> dict[str, str]:
+            raise DatabaseError("connection refused", operation="hgetall")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/boom")
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error"] == "DatabaseError"
+        assert body["message"] == "connection refused"

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -72,3 +72,6 @@ class TestExceptionHandlerWiring:
         body = response.json()
         assert body["error"] == "DatabaseError"
         assert body["message"] == "connection refused"
+        # 5xx responses must not leak internal infrastructure context such as
+        # the database operation carried in ``details``.
+        assert "details" not in body

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -38,6 +38,8 @@ def mock_ingest_settings(temp_upload_dir):
             "text/plain",
         ]
         mock.upload_dir = temp_upload_dir
+        # Default to no enqueue so the base upload tests don't require Redis.
+        mock.enqueue_enabled = False
         yield mock
 
 
@@ -209,6 +211,82 @@ class TestFilenameSanitization:
             )
 
         assert response.status_code == status.HTTP_201_CREATED
+
+
+class TestIngestEnqueue:
+    """Tests for the persist+enqueue wiring gated by settings.enqueue_enabled."""
+
+    def test_enqueue_called_when_enabled(
+        self, client, sample_pdf, mock_ingest_settings
+    ):
+        """When enqueue is enabled, the batch and its jobs are enqueued."""
+        mock_ingest_settings.enqueue_enabled = True
+
+        with (
+            patch("rag_processor.api.ingest.detect_mime_type") as mock_detect,
+            patch("rag_processor.api.ingest.enqueue_batch_jobs") as mock_enqueue,
+        ):
+            mock_detect.return_value = "application/pdf"
+
+            response = client.post(
+                "/api/v1/ingest",
+                files=[("files", ("test.pdf", sample_pdf, "application/pdf"))],
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_enqueue.assert_called_once()
+        # First positional arg is the batch, second is the list of jobs.
+        batch_arg, jobs_arg = mock_enqueue.call_args[0]
+        assert batch_arg.total_files == 1
+        assert len(jobs_arg) == 1
+
+    def test_enqueue_not_called_when_disabled(
+        self, client, sample_pdf, mock_ingest_settings
+    ):
+        """When enqueue is disabled (default), no enqueue is attempted."""
+        mock_ingest_settings.enqueue_enabled = False
+
+        with (
+            patch("rag_processor.api.ingest.detect_mime_type") as mock_detect,
+            patch("rag_processor.api.ingest.enqueue_batch_jobs") as mock_enqueue,
+        ):
+            mock_detect.return_value = "application/pdf"
+
+            response = client.post(
+                "/api/v1/ingest",
+                files=[("files", ("test.pdf", sample_pdf, "application/pdf"))],
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_enqueue.assert_not_called()
+
+    def test_enqueue_failure_returns_503_and_rolls_back(
+        self, client, sample_pdf, mock_ingest_settings, temp_upload_dir
+    ):
+        """A Redis/RQ failure rolls back uploads and returns 503."""
+        from pathlib import Path
+
+        mock_ingest_settings.enqueue_enabled = True
+
+        with (
+            patch("rag_processor.api.ingest.detect_mime_type") as mock_detect,
+            patch(
+                "rag_processor.api.ingest.enqueue_batch_jobs",
+                side_effect=ConnectionError("redis down"),
+            ),
+            patch("rag_processor.api.ingest.get_redis_store"),
+        ):
+            mock_detect.return_value = "application/pdf"
+
+            response = client.post(
+                "/api/v1/ingest",
+                files=[("files", ("test.pdf", sample_pdf, "application/pdf"))],
+            )
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        # Upload directory for the batch must have been cleaned up on rollback.
+        batch_dirs = [p for p in Path(temp_upload_dir).iterdir() if p.is_dir()]
+        assert batch_dirs == []
 
 
 class TestIngestHealth:

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -274,7 +274,6 @@ class TestIngestEnqueue:
                 "rag_processor.api.ingest.enqueue_batch_jobs",
                 side_effect=ConnectionError("redis down"),
             ),
-            patch("rag_processor.api.ingest.get_redis_store"),
         ):
             mock_detect.return_value = "application/pdf"
 

--- a/tests/unit/test_jobs_async.py
+++ b/tests/unit/test_jobs_async.py
@@ -1,0 +1,118 @@
+"""Tests for async wrappers and worker failure handling in queue/jobs.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import uuid4
+
+import fakeredis
+import pytest
+
+from rag_processor.models.batch import Batch, BatchStatus
+from rag_processor.models.job import (
+    FileClassification,
+    Job,
+    JobStatus,
+    Pipeline,
+)
+from rag_processor.queue.redis_store import RedisStore
+
+
+def _job(batch_id) -> Job:
+    return Job(
+        batch_id=batch_id,
+        filename="x.pdf",
+        file_path="/data/uploads/x.pdf",
+        file_type="application/pdf",
+        file_size_bytes=10,
+        classification=FileClassification.BORN_DIGITAL_PDF,
+        routed_to=Pipeline.DOC_PROCESSING,
+    )
+
+
+class TestAsyncWrappers:
+    """The async wrappers must offload to a thread and return the value."""
+
+    @pytest.mark.asyncio
+    async def test_get_batch_status_async_returns_value(self) -> None:
+        batch = Batch(created_by_email="a@b.c", status=BatchStatus.QUEUED)
+        with patch(
+            "rag_processor.queue.jobs.get_batch_status",
+            return_value=(batch, []),
+        ):
+            from rag_processor.queue.jobs import get_batch_status_async
+
+            result_batch, jobs = await get_batch_status_async(batch.batch_id)
+
+        assert result_batch is batch
+        assert jobs == []
+
+    @pytest.mark.asyncio
+    async def test_get_job_status_async_returns_value(self) -> None:
+        job = _job(uuid4())
+        with patch("rag_processor.queue.jobs.get_job_status", return_value=job):
+            from rag_processor.queue.jobs import get_job_status_async
+
+            result = await get_job_status_async(job.job_id)
+
+        assert result is job
+
+
+class TestProcessJobTaskFailure:
+    """process_job_task must record pipeline failures against the job/batch."""
+
+    def setup_method(self) -> None:
+        self.fake_redis = fakeredis.FakeRedis(decode_responses=True)
+        self.store = RedisStore(redis_client=self.fake_redis)
+
+    def test_pipeline_failure_marks_job_failed(self) -> None:
+        batch = Batch(created_by_email="a@b.c", total_files=1)
+        job = _job(batch.batch_id)
+        self.store.save_batch(batch)
+        self.store.save_job(job)
+
+        with (
+            patch(
+                "rag_processor.queue.jobs.get_redis_store",
+                return_value=self.store,
+            ),
+            patch(
+                "rag_processor.queue.jobs._run_pipeline",
+                side_effect=RuntimeError("pipeline boom"),
+            ),
+        ):
+            from rag_processor.queue.jobs import process_job_task
+
+            result = process_job_task(str(job.job_id))
+
+        assert result["status"] == "failed"
+        assert "pipeline boom" in result["error"]
+
+        stored = self.store.get_job(job.job_id)
+        assert stored is not None
+        assert stored.status == JobStatus.FAILED
+        assert stored.error_message == "pipeline boom"
+
+        # Batch must reflect the failure, not remain stuck in PROCESSING.
+        stored_batch = self.store.get_batch(batch.batch_id)
+        assert stored_batch is not None
+        assert stored_batch.status == BatchStatus.FAILED
+
+    def test_pipeline_success_marks_job_completed(self) -> None:
+        batch = Batch(created_by_email="a@b.c", total_files=1)
+        job = _job(batch.batch_id)
+        self.store.save_batch(batch)
+        self.store.save_job(job)
+
+        with patch(
+            "rag_processor.queue.jobs.get_redis_store",
+            return_value=self.store,
+        ):
+            from rag_processor.queue.jobs import process_job_task
+
+            result = process_job_task(str(job.job_id))
+
+        assert result["status"] == "completed"
+        stored = self.store.get_job(job.job_id)
+        assert stored is not None
+        assert stored.status == JobStatus.COMPLETED

--- a/tests/unit/test_jobs_async.py
+++ b/tests/unit/test_jobs_async.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import fakeredis
@@ -56,6 +56,76 @@ class TestAsyncWrappers:
             result = await get_job_status_async(job.job_id)
 
         assert result is job
+
+
+class TestEnqueueBatchJobsRollback:
+    """enqueue_batch_jobs must be all-or-nothing on partial enqueue failure."""
+
+    def setup_method(self) -> None:
+        self.fake_redis = fakeredis.FakeRedis(decode_responses=True)
+        self.store = RedisStore(redis_client=self.fake_redis)
+
+    def test_partial_enqueue_failure_cancels_and_rolls_back(self) -> None:
+        batch = Batch(created_by_email="a@b.c", total_files=2)
+        job1 = _job(batch.batch_id)
+        job2 = _job(batch.batch_id)
+
+        # First enqueue succeeds and returns a cancellable RQ job; the second
+        # raises, which must trigger rollback of the first.
+        rq_job1 = MagicMock()
+        mock_client = MagicMock()
+        mock_client.enqueue.side_effect = [rq_job1, ConnectionError("redis down")]
+
+        from rag_processor.queue.jobs import enqueue_batch_jobs
+
+        with (
+            patch(
+                "rag_processor.queue.jobs.get_redis_store",
+                return_value=self.store,
+            ),
+            patch(
+                "rag_processor.queue.jobs.get_queue_client",
+                return_value=mock_client,
+            ),
+            pytest.raises(ConnectionError),
+        ):
+            enqueue_batch_jobs(batch, [job1, job2])
+
+        # The already-enqueued RQ job must have been cancelled and removed.
+        rq_job1.cancel.assert_called_once()
+        rq_job1.delete.assert_called_once()
+
+        # Redis state for the batch and its jobs must be gone (no orphans).
+        assert self.store.get_batch(batch.batch_id) is None
+        assert self.store.get_job(job1.job_id) is None
+        assert self.store.get_job(job2.job_id) is None
+
+    def test_successful_enqueue_returns_rq_ids(self) -> None:
+        batch = Batch(created_by_email="a@b.c", total_files=1)
+        job = _job(batch.batch_id)
+
+        rq_job = MagicMock()
+        rq_job.id = "rq-1"
+        mock_client = MagicMock()
+        mock_client.enqueue.return_value = rq_job
+
+        with (
+            patch(
+                "rag_processor.queue.jobs.get_redis_store",
+                return_value=self.store,
+            ),
+            patch(
+                "rag_processor.queue.jobs.get_queue_client",
+                return_value=mock_client,
+            ),
+        ):
+            from rag_processor.queue.jobs import enqueue_batch_jobs
+
+            ids = enqueue_batch_jobs(batch, [job])
+
+        assert ids == ["rq-1"]
+        assert self.store.get_batch(batch.batch_id) is not None
+        assert self.store.get_job(job.job_id) is not None
 
 
 class TestProcessJobTaskFailure:

--- a/tests/unit/test_jobs_async.py
+++ b/tests/unit/test_jobs_async.py
@@ -186,3 +186,63 @@ class TestProcessJobTaskFailure:
         stored = self.store.get_job(job.job_id)
         assert stored is not None
         assert stored.status == JobStatus.COMPLETED
+
+    def test_skips_when_parent_batch_missing(self) -> None:
+        # Orphan-race guard: a job whose parent batch was deleted (e.g. by
+        # enqueue rollback) must not be processed or have status written.
+        job = _job(uuid4())  # batch_id points at a batch we never save
+        self.store.save_job(job)
+
+        with patch(
+            "rag_processor.queue.jobs.get_redis_store",
+            return_value=self.store,
+        ):
+            from rag_processor.queue.jobs import process_job_task
+
+            result = process_job_task(str(job.job_id))
+
+        assert result["status"] == "skipped"
+        # Job status must remain QUEUED — the worker wrote nothing.
+        stored = self.store.get_job(job.job_id)
+        assert stored is not None
+        assert stored.status == JobStatus.QUEUED
+
+    def test_failure_recording_survives_redis_error(self) -> None:
+        # If recording the failure itself raises (e.g. Redis down), the worker
+        # must not crash — it returns the failure result cleanly.
+        from unittest.mock import MagicMock
+
+        batch = Batch(created_by_email="a@b.c", total_files=1)
+        job = _job(batch.batch_id)
+        self.store.save_batch(batch)
+        self.store.save_job(job)
+
+        # Wrap the real store so only the failure-recording update (status=FAILED)
+        # raises, while the earlier mark-processing update still works.
+        failing_store = MagicMock(wraps=self.store)
+
+        def _update(job_id_arg: object, **kwargs: object) -> None:
+            if kwargs.get("status") == JobStatus.FAILED.value:
+                msg = "redis down"
+                raise ConnectionError(msg)
+            self.store.update_job_status(job_id_arg, **kwargs)
+
+        failing_store.update_job_status.side_effect = _update
+
+        with (
+            patch(
+                "rag_processor.queue.jobs.get_redis_store",
+                return_value=failing_store,
+            ),
+            patch(
+                "rag_processor.queue.jobs._run_pipeline",
+                side_effect=RuntimeError("pipeline boom"),
+            ),
+        ):
+            from rag_processor.queue.jobs import process_job_task
+
+            # Must not raise despite update_job_status failing.
+            result = process_job_task(str(job.job_id))
+
+        assert result["status"] == "failed"
+        assert "pipeline boom" in result["error"]

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -451,6 +451,22 @@ class TestGetEventHistory:
         assert call_args[1] == 0
         assert call_args[2] == 49
 
+    @pytest.mark.asyncio
+    async def test_get_event_history_async_offloads_and_returns(self) -> None:
+        """The async wrapper forwards to the sync reader and returns its value."""
+        from rag_processor.websocket.events import get_event_history_async
+
+        events = [{"event_id": "e1"}]
+        with patch(
+            "rag_processor.websocket.events.get_event_history",
+            return_value=events,
+        ) as mock_sync:
+            result = await get_event_history_async(uuid4(), limit=25)
+
+        assert result == events
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args.kwargs["limit"] == 25
+
 
 class TestWebSocketRouter:
     """Tests for WebSocket router."""
@@ -520,7 +536,7 @@ class TestWebSocketRouter:
 
         with (
             patch(
-                "rag_processor.websocket.router.get_event_history",
+                "rag_processor.websocket.events.get_event_history",
                 return_value=mock_history,
             ),
             patch("rag_processor.websocket.router.connection_manager") as mock_manager,

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -283,11 +283,14 @@ class TestWebSocketEndpoint:
         mock_verify = AsyncMock(
             return_value={"email": "user@example.com", "user_id": "user-123"}
         )
-        mock_batch_status = MagicMock(return_value=(None, []))
+        mock_batch_status = AsyncMock(return_value=(None, []))
 
         with (
             patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
-            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch(
+                "rag_processor.websocket.router.get_batch_status_async",
+                mock_batch_status,
+            ),
         ):
             from rag_processor.websocket.router import websocket_batch_status
 
@@ -315,7 +318,7 @@ class TestWebSocketEndpoint:
         mock_batch = MagicMock()
         mock_batch.created_by_user_id = "u-owner"
         mock_batch.created_by_email = "owner@example.com"
-        mock_batch_status = MagicMock(return_value=(mock_batch, []))
+        mock_batch_status = AsyncMock(return_value=(mock_batch, []))
 
         mock_cm = MagicMock()
         mock_cm.connect = AsyncMock()
@@ -324,7 +327,10 @@ class TestWebSocketEndpoint:
 
         with (
             patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
-            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch(
+                "rag_processor.websocket.router.get_batch_status_async",
+                mock_batch_status,
+            ),
             patch("rag_processor.websocket.router.connection_manager", mock_cm),
         ):
             from rag_processor.websocket.router import websocket_batch_status
@@ -364,7 +370,7 @@ class TestWebSocketEndpoint:
         mock_batch = MagicMock()
         mock_batch.created_by_user_id = "u-owner"
         mock_batch.created_by_email = "owner@example.com"
-        mock_batch_status = MagicMock(return_value=(mock_batch, []))
+        mock_batch_status = AsyncMock(return_value=(mock_batch, []))
 
         mock_cm = MagicMock()
         mock_cm.connect = AsyncMock()
@@ -373,7 +379,10 @@ class TestWebSocketEndpoint:
 
         with (
             patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
-            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch(
+                "rag_processor.websocket.router.get_batch_status_async",
+                mock_batch_status,
+            ),
             patch("rag_processor.websocket.router.connection_manager", mock_cm),
         ):
             from rag_processor.websocket.router import websocket_batch_status
@@ -428,7 +437,7 @@ class TestWebSocketEndpoint:
         mock_batch = MagicMock()
         mock_batch.created_by_user_id = "user-123"
         mock_batch.created_by_email = "user@example.com"
-        mock_batch_status = MagicMock(return_value=(mock_batch, []))
+        mock_batch_status = AsyncMock(return_value=(mock_batch, []))
 
         mock_cm = MagicMock()
         mock_cm.connect = AsyncMock()
@@ -442,7 +451,10 @@ class TestWebSocketEndpoint:
 
         with (
             patch("rag_processor.websocket.router.verify_ws_token", mock_verify),
-            patch("rag_processor.websocket.router.get_batch_status", mock_batch_status),
+            patch(
+                "rag_processor.websocket.router.get_batch_status_async",
+                mock_batch_status,
+            ),
             patch("rag_processor.websocket.router.connection_manager", mock_cm),
             patch(
                 "rag_processor.websocket.router._websocket_message_loop",

--- a/tests/unit/test_websocket_router.py
+++ b/tests/unit/test_websocket_router.py
@@ -171,7 +171,7 @@ class TestReplayEvents:
         mock_cm.send_personal = AsyncMock()
 
         with (
-            patch("rag_processor.websocket.router.get_event_history", mock_history),
+            patch("rag_processor.websocket.events.get_event_history", mock_history),
             patch("rag_processor.websocket.router.connection_manager", mock_cm),
         ):
             from rag_processor.websocket.router import _replay_events
@@ -197,7 +197,7 @@ class TestReplayEvents:
         mock_cm.send_personal = AsyncMock()
 
         with (
-            patch("rag_processor.websocket.router.get_event_history", mock_history),
+            patch("rag_processor.websocket.events.get_event_history", mock_history),
             patch("rag_processor.websocket.router.connection_manager", mock_cm),
         ):
             from rag_processor.websocket.router import _replay_events

--- a/uv.lock
+++ b/uv.lock
@@ -3025,11 +3025,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Implements the **top-3 refactors** from the architecture review and the follow-up review fixes. Retitled `refactor:` → **`feat:`** because this completes the ingest pipeline and adds a public `enqueue_enabled` setting (feature-level), so semantic-release cuts a minor bump; a CHANGELOG entry was added under `[Unreleased] → Added`.

### 🥇 #1 — Unified Redis access + non-blocking reads
- **`core/redis.py`**: single pooled synchronous client factory (decoded + raw pools), lazy init now guarded by a `threading.Lock`, graceful shutdown.
- Async API/WebSocket handlers use thread-offloaded `get_batch_status_async` / `get_job_status_async` so sync Redis never blocks the event loop.
- Deduped `_parse_iso_datetime` → `utils.time_utils.parse_iso_datetime`.

### 🥈 #2 — Completed ingest → persist → enqueue
- `ingest_files` persists + enqueues (`enqueue_batch_jobs`), gated behind default-off `enqueue_enabled`. **All-or-nothing**: partial enqueue failures cancel enqueued RQ jobs and roll back Redis state; on-disk rollback now logs (not silently swallows) cleanup failures.
- Worker hardened: pipeline failures are recorded **best-effort** (won't crash the worker if Redis is the correlated cause), and a job whose parent batch has vanished is skipped to avoid orphan hashes.

### 🥉 #3 — Consolidated auth + wired exception hierarchy
- Shared JWKS loader (single-flight `asyncio.Lock`, documented cross-loop caveat), key-resolution and decode helpers; HTTP and WS now accept identical tokens (RS256 + aud + iss + shared leeway).
- `ProjectBaseError` mapped to HTTP responses via a FastAPI exception handler.

## Review fixes applied (commit `6833ff5`)
Addressed all six in-scope items from @williaby's review (worker-boundary guarding, enqueue/cancel orphan race + doc, silent rmtree cleanup, async-wrapper consistency, Redis pool lock, asyncio.Lock note).

## CI dependency fix (commit `886060f`)
The Code Quality Checks job's pip-audit scan started failing on four newly disclosed `pyjwt 2.12.1` advisories (PYSEC-2026-175/177/178/179). Bumped pyjwt → **2.13.0** in the lockfile (the `>=2.8.0` constraint already permitted it); auth tests pass unchanged.

## Verification
- **450 passed**, 1 skipped · ruff + format clean · basedpyright 0 errors · coverage ~92% · SonarCloud gate passed · perf improved (-37.8% p95).

https://claude.ai/code/session_01PA6dtgMhfzSe22VVtqBfxE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable background job enqueueing with atomic enqueue/rollback behavior
  * Unified token validation for HTTP and WebSocket with improved expiry tolerance
  * Domain-aware exception handling mapped to HTTP responses

* **Improvements**
  * Non-blocking async status/event lookups for better responsiveness
  * Centralized Redis connection management with graceful shutdown
  * Upload safety checks and robust enqueue error handling

* **Tests**
  * Expanded unit/integration tests covering auth, enqueue workflows, async wrappers, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->