### PR TITLE
fix: accept unfixed base-image CVEs in Trivy container scan

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -13,6 +13,7 @@ on:
       - '.dockerignore'
       - 'pyproject.toml'
       - 'uv.lock'
+      - '.trivyignore'
   pull_request:
     branches: [main, master, develop]
     paths:
@@ -21,6 +22,7 @@ on:
       - '.dockerignore'
       - 'pyproject.toml'
       - 'uv.lock'
+      - '.trivyignore'
   schedule:
     # Weekly scan on Wednesdays at 7 AM UTC
     - cron: '0 7 * * 3'

--- a/.trivyignore
+++ b/.trivyignore
@@ -39,3 +39,37 @@ GHSA-f83h-ghpp-7wcc
 # Decision: Accept risk; revisit when Debian 13 releases a patch
 # Review Date: 2026-05-21
 CVE-2025-69720
+
+# Perl base-image CVEs (Archive::Tar / IO-Compress / Perl core)
+# ----------------------------------------------------------
+# Status: No upstream Debian fix available as of 2026-06-02. All five are
+#         reported by Trivy as "affected" with no Fixed Version.
+# Severity: CRITICAL x2, HIGH x3
+# Packages: perl-base, perl-IO-Compress (baked into python:3.12-slim)
+#
+# CVEs:
+# - CVE-2026-42496 (CRITICAL) Archive::Tar < 3.08 symlink extraction
+# - CVE-2026-8376  (CRITICAL) Perl <= 5.43.10 heap buffer overflow (compile)
+# - CVE-2026-42497 (HIGH)     Archive::Tar < 3.08 hardlink extraction
+# - CVE-2026-48962 (HIGH)     perl-IO-Compress arbitrary code execution
+# - CVE-2026-9538  (HIGH)     Archive::Tar < 3.10 memory issue
+#
+# Risk Assessment:
+# - Perl is a transitive dependency of the Debian base image (pulled in via
+#   perl-base / dpkg tooling); it is NOT used by this application, which is a
+#   pure-Python FastAPI service. No application code path invokes perl,
+#   Archive::Tar, or IO-Compress.
+# - The base image is already pinned to the latest python:3.12-slim digest, so
+#   there is no newer image that resolves these; they are unfixed upstream.
+# - The container runs headless as a non-root user; no untrusted input is
+#   passed to any Perl tooling, so the practical attack surface is ~zero.
+# - perl-base cannot be safely purged from python:3.12-slim (dpkg depends on it).
+#
+# Decision: Accept risk; revisit when Debian ships fixed perl packages, or
+#           migrate to a perl-free base (e.g. distroless) in a tracked follow-up.
+# Review Date: 2026-06-02
+CVE-2026-42496
+CVE-2026-8376
+CVE-2026-42497
+CVE-2026-48962
+CVE-2026-9538

--- a/docs/template_feedback.md
+++ b/docs/template_feedback.md
@@ -148,6 +148,29 @@ use), (b) mark it `; python_version >= '3.11'` so 3.10 stays installable, or (c)
 
 ---
 
+### Container security scan does not re-trigger on `.trivyignore` changes
+
+- **Priority**: Medium
+- **Category**: CI/CD
+- **Discovered**: 2026-06-02
+
+**Issue**: `container-security.yml` filters its `push`/`pull_request` triggers on `paths` that include the Dockerfile
+and dependency files but **not** `.trivyignore`. Because the scan also fails on unfixed base-image CVEs (the reusable
+workflow runs with `IGNORE_UNFIXED: false`), the only supported remediation for an unavoidable finding is to add the
+CVE to `.trivyignore` — yet editing that file does not trigger the scan to re-validate. The fix only takes effect on
+the next Dockerfile/dependency change or the weekly scheduled run, so a PR that adds an ignore entry cannot prove it
+resolves the failure.
+
+**Context**: Discovered while clearing five unfixed Perl base-image CVEs (CVE-2026-42496 et al.) from
+`python:3.12-slim`. The `.trivyignore`-only fix produced no scan run, leaving the change unverifiable in CI.
+
+**Suggested Fix**: Add `.trivyignore` (and `.trivyignore.yaml`) to the `paths` filters of both the `push` and
+`pull_request` triggers in the container-security workflow.
+
+**Affected Files**: `{{cookiecutter.project_slug}}/.github/workflows/container-security.yml`
+
+---
+
 ## Submitting Feedback
 
 Once you've collected feedback, you can:


### PR DESCRIPTION
## Summary

Resolves the failing **Container Security Scan / Trivy** check by accepting a set of base-image CVEs that have no upstream fix and are not reachable by this application, with a documented risk assessment for each. Also wires the scan to re-trigger on `.trivyignore` changes so the suppression self-verifies.

## Changes

- **`.trivyignore`**: add 5 unfixed Perl base-image CVEs (Archive::Tar / Perl core / IO-Compress) reported as "affected" with no Fixed Version:
  - `CVE-2026-42496` (CRITICAL), `CVE-2026-8376` (CRITICAL), `CVE-2026-42497` (HIGH), `CVE-2026-48962` (HIGH), `CVE-2026-9538` (HIGH)
- **`.github/workflows/container-security.yml`**: add `.trivyignore` to the push and pull_request `paths:` filters so the container scan re-runs when the ignore list changes (the fix self-verifies on this PR).
- **`docs/template_feedback.md`**: note the recurring unfixed-base-image-CVE pattern for the template.

## Why these are accepted (not fixed)

- `perl-base` / `perl-IO-Compress` are transitive Debian base-image dependencies pulled in via dpkg tooling in `python:3.12-slim`. This is a pure-Python FastAPI service; no application code path invokes perl, `Archive::Tar`, or `IO-Compress`.
- The base image is already pinned to the latest `python:3.12-slim` digest, so there is no newer image that resolves these; they are unfixed upstream in Debian as of 2026-06-02.
- The container runs headless as a non-root user with no untrusted input reaching any Perl tooling, so the practical attack surface is effectively zero.
- `perl-base` cannot be safely purged (dpkg depends on it).

**Decision:** accept with monitoring; revisit when Debian ships fixed perl packages, or migrate to a perl-free base (e.g. distroless) in a tracked follow-up. Each entry carries a Review Date in `.trivyignore`.

## Test plan

- [x] `.trivyignore` entries are documented with severity, risk assessment, and review date per the project's unfixed-CVE policy.
- [ ] Container Security Scan / Trivy passes on this PR (re-triggered via the new `paths:` entry).

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container security workflow to re-trigger when vulnerability ignore rules are updated.

* **Documentation**
  * Added documented entries for Perl base-image vulnerabilities with risk assessment and CVE references.
  * Updated workflow feedback documentation to reflect the fix for vulnerability scanning triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->