### PR TITLE
feat(ci): add qlty gate and weekly health scan

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -5,16 +5,23 @@ on:
     workflows: ["CI"]
     types:
       - completed
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full-codebase health scan: Monday 07:00 UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
 
 permissions: read-all
 
 concurrency:
-  group: qlty-coverage-${{ github.event.workflow_run.head_branch }}
+  group: qlty-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Coverage upload: runs after CI workflow completes successfully.
   qlty:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-coverage.yml@74c633acfdd5f707ab154fd59bd212c6df663dd6 # main
     permissions:
       contents: read
@@ -26,3 +33,26 @@ jobs:
       workflow-run-id: ${{ github.event.workflow_run.id }}
     secrets:
       QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+
+  # PR gate: diff mode, block merges that introduce medium+ severity issues.
+  # Check name: "qlty-gate / Qlty Gate" -- required by org docs-tier ruleset.
+  qlty-gate:
+    if: github.event_name == 'pull_request'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    permissions:
+      contents: read
+    with:
+      fail-level: medium
+      upstream: origin/${{ github.base_ref }}
+
+  # Weekly health scan: full codebase, informational only.
+  # Remove no-fail once existing qlty debt is resolved.
+  qlty-health:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    permissions:
+      contents: read
+    with:
+      fail-level: high
+      check-all: true
+      no-fail: true

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -38,7 +38,7 @@ jobs:
   # Check name: "qlty-gate / Qlty Gate" -- required by org docs-tier ruleset.
   qlty-gate:
     if: github.event_name == 'pull_request'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@1561a3ef04892ffd6c4a0c4c46fdf1de5a34ed02 # .github#188
     permissions:
       contents: read
     with:
@@ -49,7 +49,7 @@ jobs:
   # Remove no-fail once existing qlty debt is resolved.
   qlty-health:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@1561a3ef04892ffd6c4a0c4c46fdf1de5a34ed02 # .github#188
     permissions:
       contents: read
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### CI/CD
+
+- **Qlty PR gate and weekly health scan**: `qlty.yml` now runs the
+  `python-qlty-gate` reusable workflow on every pull request to `main` in diff
+  mode (`fail-level: medium`) to block merges that introduce medium or higher
+  severity issues, and runs a Monday 07:00 UTC full-codebase health scan that is
+  informational only (`no-fail: true`). The reusable workflow is pinned to a
+  `main`-reachable commit in `ByronWilliamsCPA/.github` (from `.github#188`).
+
 #### WebSocket & Rate Limiting (Tier 2)
 
 - **Proxy-aware rate limiting (H6)**: `RateLimitMiddleware` can resolve the


### PR DESCRIPTION
Adds qlty-gate job (PR diff gate, fail-level medium) and qlty-health job (weekly Monday scan, informational). Depends on ByronWilliamsCPA/.github#188 merging first. After both merge, PATCH org ruleset 17200214 to add qlty-gate / Qlty Gate to required_status_checks.