### PR TITLE
feat: salvage PR #60 pipeline extras (event bridge, app factory/DI, CORS dedupe, compose Redis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helper, so both enforce the same RS256 + audience + issuer checks and clock-skew leeway.
 - **Domain exception hierarchy wired into FastAPI** via an exception handler
   mapping `ProjectBaseError` subclasses to HTTP responses.
+- **Real-time event delivery to WebSocket clients** via a new
+  `EventBridge` (`websocket/bridge.py`) that subscribes to the Redis
+  `batch:*:events` pub/sub channels and relays each event to the locally
+  connected clients. Started and stopped in the application lifespan; degrades
+  gracefully when Redis is unavailable and reconnects with bounded exponential
+  backoff after transient outages. Previously, worker events were published to
+  Redis but never reached browsers (clients saw only the initial snapshot and
+  `last_event_id` replay).
+- **Application factory** (`create_app()` in `main.py`) is now the single source
+  of truth for middleware ordering and CORS, replacing the import-time global
+  app construction. The `FileRouter` is injected via `Depends(get_file_router)`
+  (`api/dependencies.py`) instead of a module-level singleton, giving tests an
+  override seam.
+
+### Fixed (Architecture Review follow-up)
+
+- **Duplicate CORS middleware removed**: `add_security_middleware` no longer
+  registers a second, conflicting `CORSMiddleware` (empty origins,
+  `allow_headers=["*"]`) on top of the application's own. It now configures CORS
+  only when the caller explicitly supplies `allowed_origins`; `create_app` owns
+  CORS for the gateway.
+- **Docker Compose Redis wiring**: the `app` and `worker` services only received
+  `REDIS_URL`/`LOG_LEVEL`, but application code reads the `RAG_PROCESSOR_`-prefixed
+  settings, so both silently fell back to `redis_host=localhost` and never
+  reached the `redis` service. Added `RAG_PROCESSOR_REDIS_*` (plus log/enqueue)
+  variables to both services and switched the worker to the `rq worker` console
+  script.
 
 #### Phase 0: Foundation Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   manager uses a plain `dict` with non-resurrecting cleanup (`.get`/`.pop`) in
   `broadcast` and `disconnect`, so a batch emptied/removed by a concurrent
   disconnect is not silently recreated as an empty set (key leak).
+- **Event bridge listener resilience**: the Redis pub/sub `EventBridge` no longer
+  dies silently on an unexpected message. `_relay` drops valid-but-non-object
+  JSON payloads instead of raising `AttributeError`; the listener wraps each
+  relay in a resilience boundary so one bad event (or a client disconnect during
+  broadcast) is logged and skipped rather than killing the task; `_cleanup` uses
+  separate suppress blocks so the connection handle is always closed (no leak per
+  reconnect); and the listener task carries a done-callback that records an
+  unexpected exit and clears `running` so it stops reporting a false healthy
+  state. The reconnect backoff now resets only on a cleanly relayed event, not on
+  a bare subscription acknowledgement.
+- **`broadcast` tolerates abrupt client disconnects**: `ConnectionManager.broadcast`
+  now also catches `WebSocketDisconnect` (which subclasses only `Exception`), so a
+  client dropping mid-broadcast prunes that client instead of aborting delivery to
+  the remaining clients and propagating to the caller.
 - **Rate-limit tracking-table bound (H6 hardening)**: `max_tracked_ips` is now
   enforced on insert in `RateLimitMiddleware.dispatch`, not only during the
   time-gated periodic cleanup. This keeps the cap effective under a flood of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,16 +18,33 @@ services:
     ports:
       - "${APP_PORT:-8000}:8000"
     environment:
-      # Core settings
+      # Core settings. Application code reads configuration via the
+      # RAG_PROCESSOR_ env prefix (see core/config.py); the unprefixed names
+      # below are retained only for external tooling and are NOT read by the app.
       ENVIRONMENT: ${ENVIRONMENT:-development}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       JSON_LOGS: ${JSON_LOGS:-false}
+      RAG_PROCESSOR_LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      RAG_PROCESSOR_JSON_LOGS: ${JSON_LOGS:-false}
 
-      # Database configuration
-      DATABASE_URL: ${DATABASE_URL:-postgresql://rag_processor:password@db:5432/rag_processor}
+      # Database configuration. The default credential is a non-secret local
+      # development placeholder (overridden in real deployments via DATABASE_URL);
+      # trufflehog:ignore marks it so the secret scanner does not treat the dummy
+      # value as a leaked credential.
+      DATABASE_URL: ${DATABASE_URL:-postgresql://rag_processor:password@db:5432/rag_processor}  # trufflehog:ignore
 
-      # Redis configuration (job queue)
+      # Redis configuration. The app builds its Redis client from the discrete
+      # RAG_PROCESSOR_REDIS_* settings (core/redis.py), NOT from REDIS_URL, so
+      # these must point at the `redis` service or the client silently falls
+      # back to localhost and never connects.
       REDIS_URL: redis://:${REDIS_PASSWORD:-redispassword}@redis:6379/0
+      RAG_PROCESSOR_REDIS_HOST: redis
+      RAG_PROCESSOR_REDIS_PORT: "6379"
+      RAG_PROCESSOR_REDIS_PASSWORD: ${REDIS_PASSWORD:-redispassword}
+      RAG_PROCESSOR_REDIS_DB: "0"
+
+      # Persistence/enqueue is enabled because this stack runs an RQ worker.
+      RAG_PROCESSOR_ENQUEUE_ENABLED: ${ENQUEUE_ENABLED:-true}
 
       # Sentry (error tracking)
       # SENTRY_DSN: ${SENTRY_DSN:-}
@@ -167,9 +184,11 @@ services:
         BUILD_ENV: ${ENVIRONMENT:-development}
     image: rag_processor:${VERSION:-latest}
     container_name: rag_processor-worker
-    # Process jobs from high, default, and low priority queues
+    # Process jobs from high, default, and low priority queues. Use the `rq`
+    # console script rather than `python -m rq.cli`, which is not a stable
+    # module entry point across rq versions.
     command: >
-      python -m rq.cli worker
+      rq worker
       high default low
       --url redis://:${REDIS_PASSWORD:-redispassword}@redis:6379/0
       --with-scheduler
@@ -178,6 +197,17 @@ services:
       ENVIRONMENT: ${ENVIRONMENT:-development}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       REDIS_URL: redis://:${REDIS_PASSWORD:-redispassword}@redis:6379/0
+      # process_job_task builds its job store and event publisher from the
+      # discrete RAG_PROCESSOR_REDIS_* settings (core/redis.py). The RQ --url
+      # flag only configures the queue connection, so these are required for the
+      # worker to record job state and publish WebSocket events.
+      RAG_PROCESSOR_LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      RAG_PROCESSOR_JSON_LOGS: ${JSON_LOGS:-false}
+      RAG_PROCESSOR_REDIS_HOST: redis
+      RAG_PROCESSOR_REDIS_PORT: "6379"
+      RAG_PROCESSOR_REDIS_PASSWORD: ${REDIS_PASSWORD:-redispassword}
+      RAG_PROCESSOR_REDIS_DB: "0"
+      RAG_PROCESSOR_ENQUEUE_ENABLED: ${ENQUEUE_ENABLED:-true}
 
     volumes:
       # Shared file storage with gateway

--- a/src/rag_processor/api/dependencies.py
+++ b/src/rag_processor/api/dependencies.py
@@ -1,0 +1,28 @@
+"""Shared FastAPI dependency providers for the API layer.
+
+These providers give route handlers an injectable seam for collaborators that
+were previously instantiated as module-level globals. Using ``Depends`` keeps
+construction lazy (nothing is built at import time) and lets tests override
+collaborators via ``app.dependency_overrides`` instead of monkeypatching module
+globals.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from rag_processor.routing import FileRouter
+
+
+@lru_cache(maxsize=1)
+def get_file_router() -> FileRouter:
+    """Return the process-wide :class:`FileRouter` instance.
+
+    The router (and the magic/pdf parsers it wraps) is comparatively expensive
+    to build, so it is cached for the lifetime of the process. Tests can
+    override this dependency to inject a stub router.
+
+    Returns:
+        The shared FileRouter instance.
+    """
+    return FileRouter()

--- a/src/rag_processor/api/ingest.py
+++ b/src/rag_processor/api/ingest.py
@@ -17,6 +17,7 @@ import magic
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
+from rag_processor.api.dependencies import get_file_router
 from rag_processor.auth.dependencies import get_current_user
 from rag_processor.auth.models import CloudflareUser
 from rag_processor.core.config import settings
@@ -38,9 +39,6 @@ router = APIRouter(prefix="/ingest", tags=["ingest"])
 
 # Compile regex for filename sanitization
 SAFE_FILENAME_PATTERN = re.compile(r"[^\w\s\-.]")
-
-# File router for classification and pipeline routing
-file_router = FileRouter()
 
 
 class JobResponse(BaseModel):
@@ -267,6 +265,7 @@ async def ingest_files(
         Form(description="Target vector store for handoff"),
     ] = None,
     user: CloudflareUser = Depends(get_current_user),
+    file_router: FileRouter = Depends(get_file_router),
 ) -> IngestResponse:
     """Upload files for RAG pipeline processing.
 
@@ -282,6 +281,7 @@ async def ingest_files(
         priority: Processing priority (high, normal, low).
         target_vector_store: Optional target vector store identifier.
         user: Authenticated user from Cloudflare Access.
+        file_router: Injected file classification and pipeline routing service.
 
     Returns:
         IngestResponse containing the new batch ID, batch status, total

--- a/src/rag_processor/main.py
+++ b/src/rag_processor/main.py
@@ -1,11 +1,19 @@
 """FastAPI application entry point for RAG Processor Gateway.
 
-This module creates and configures the FastAPI application with:
+This module exposes an application factory, :func:`create_app`, which builds and
+configures a fully wired FastAPI application with:
+
 - Health check endpoints for Kubernetes probes
-- CORS middleware for frontend integration
+- CORS middleware for frontend integration (single source of truth)
 - Security middleware (headers, rate limiting, SSRF prevention)
 - Correlation ID middleware for distributed tracing
 - Cloudflare Access authentication middleware
+- A Redis pub/sub -> WebSocket bridge for real-time batch events
+- The centralized exception hierarchy mapped to HTTP responses
+
+A module-level ``app`` instance is created from the factory for uvicorn
+(``uvicorn rag_processor.main:app``). Tests can call :func:`create_app` directly
+to build isolated instances with overridden dependencies.
 """
 
 from __future__ import annotations
@@ -33,12 +41,14 @@ from rag_processor.middleware import (
     get_correlation_id,
 )
 from rag_processor.utils.logging import get_logger, setup_logging
+from rag_processor.websocket.bridge import EventBridge
 from rag_processor.websocket.router import router as websocket_router
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-# Configure structured logging
+# Configure structured logging once at import time so that any module-level
+# logging during application construction is formatted consistently.
 setup_logging(
     level=settings.log_level,
     json_logs=settings.json_logs,
@@ -51,18 +61,25 @@ logger = get_logger(__name__)
 # must be withheld from clients to avoid leaking internal infrastructure.
 _SERVER_ERROR_THRESHOLD = 500
 
+# Versioned API mount point shared by the user, ingest, and batch routers.
+_API_V1_PREFIX = "/api/v1"
+
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan handler for startup and shutdown events.
+
+    On startup it launches the Redis pub/sub -> WebSocket :class:`EventBridge`
+    so that events published by background workers are relayed to connected
+    clients. On shutdown the bridge is stopped and the shared Redis pools are
+    released cleanly.
 
     Args:
         app: The FastAPI application instance.
 
     Yields:
-        None after startup, cleanup runs after yield on shutdown.
+        None after startup; cleanup runs after yield on shutdown.
     """
-    # Startup
     logger.info(
         "Starting RAG Processor Gateway",
         version=__version__,
@@ -70,75 +87,42 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
         cloudflare_enabled=settings.cloudflare_enabled,
     )
 
+    # Start the event bridge. It degrades gracefully if Redis is unavailable,
+    # so a missing broker never blocks application startup.
+    bridge = EventBridge()
+    await bridge.start()
+    app.state.event_bridge = bridge
+
     yield
 
     # Shutdown
+    await bridge.stop()
     logger.info("Shutting down RAG Processor Gateway")
     close_redis_pools()
 
 
-# Create FastAPI application
-app = FastAPI(
-    title="RAG Processor Gateway",
-    description="API Gateway for RAG file ingestion pipeline",
-    version=__version__,
-    docs_url="/docs",
-    redoc_url="/redoc",
-    openapi_url="/openapi.json",
-    lifespan=lifespan,
-)
+def _resolve_cors_origins() -> list[str]:
+    """Resolve and validate the configured CORS origins.
 
-# Add CORS middleware (must be added before other middleware).
-# Origins come from settings so production deployments can override via
-# RAG_PROCESSOR_CORS_ALLOWED_ORIGINS. Wildcard "*" is forbidden because we send
-# credentials; reject it loudly rather than silently producing an insecure config.
-_cors_origins = list(settings.cors_allowed_origins)
-if "*" in _cors_origins:
-    msg = (
-        "CORS allow_origins=['*'] is not permitted with allow_credentials=True. "
-        "Set RAG_PROCESSOR_CORS_ALLOWED_ORIGINS to an explicit list of origins."
-    )
-    raise RuntimeError(msg)
+    Wildcard ``"*"`` is forbidden because the gateway sends credentials; reject
+    it loudly rather than silently producing an insecure configuration.
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_cors_origins,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=[
-        "Authorization",
-        "Content-Type",
-        "X-Correlation-ID",
-        "X-Request-ID",
-        "Cf-Access-Jwt-Assertion",
-    ],
-    expose_headers=["X-Correlation-ID", "X-Request-ID"],
-)
+    Returns:
+        The explicit list of allowed CORS origins.
 
-# Add correlation ID middleware for distributed tracing
-app.add_middleware(CorrelationMiddleware)
-
-# Add Cloudflare Access authentication middleware
-app.add_middleware(CloudflareAuthMiddleware)
-
-# Add security middleware (headers, rate limiting, SSRF prevention)
-security_config = SecurityConfig(
-    enable_rate_limiting=settings.rate_limiting_enabled,
-    rate_limit_rpm=settings.rate_limit_rpm,
-    trust_proxy_headers=settings.rate_limit_trust_proxy,
-    client_ip_header=settings.rate_limit_client_ip_header,
-)
-add_security_middleware(app, security_config)
-
-# Include routers
-app.include_router(health_router)
-app.include_router(user_router, prefix="/api/v1")
-app.include_router(ingest_router, prefix="/api/v1")
-app.include_router(batch_router, prefix="/api/v1")
-app.include_router(websocket_router)
+    Raises:
+        RuntimeError: If the wildcard origin is configured.
+    """
+    cors_origins = list(settings.cors_allowed_origins)
+    if "*" in cors_origins:
+        msg = (
+            "CORS allow_origins=['*'] is not permitted with allow_credentials=True. "
+            "Set RAG_PROCESSOR_CORS_ALLOWED_ORIGINS to an explicit list of origins."
+        )
+        raise RuntimeError(msg)
+    return cors_origins
 
 
-@app.exception_handler(ProjectBaseError)
 async def handle_project_error(
     request: Request,  # noqa: ARG001 - required by FastAPI handler signature
     exc: ProjectBaseError,
@@ -191,16 +175,6 @@ async def handle_project_error(
     return JSONResponse(status_code=status, content=exc.to_dict())
 
 
-@app.get(
-    "/",
-    tags=["root"],
-    summary="API information",
-    description=(
-        "Returns basic API metadata including the service name, version, "
-        "and the path to the interactive OpenAPI docs. Requires Cloudflare "
-        "Access authentication when `CLOUDFLARE_ENABLED=true`."
-    ),
-)
 async def root() -> dict[str, str]:
     """API information.
 
@@ -220,5 +194,90 @@ async def root() -> dict[str, str]:
     }
 
 
+def create_app() -> FastAPI:
+    """Build and configure the FastAPI application.
+
+    This is the single place where middleware ordering, CORS, routers, and the
+    exception hierarchy are assembled. Building the app inside a factory (rather
+    than at import time) keeps construction explicit and lets tests create
+    isolated instances with overridden dependencies.
+
+    Returns:
+        A fully configured FastAPI application.
+    """
+    app = FastAPI(
+        title="RAG Processor Gateway",
+        description="API Gateway for RAG file ingestion pipeline",
+        version=__version__,
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_url="/openapi.json",
+        lifespan=lifespan,
+    )
+
+    # CORS middleware (single source of truth, added before other middleware).
+    # Origins come from settings so production deployments override via
+    # RAG_PROCESSOR_CORS_ALLOWED_ORIGINS.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_resolve_cors_origins(),
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=[
+            "Authorization",
+            "Content-Type",
+            "X-Correlation-ID",
+            "X-Request-ID",
+            "Cf-Access-Jwt-Assertion",
+        ],
+        expose_headers=["X-Correlation-ID", "X-Request-ID"],
+    )
+
+    # Correlation ID middleware for distributed tracing.
+    app.add_middleware(CorrelationMiddleware)
+
+    # Cloudflare Access authentication middleware.
+    app.add_middleware(CloudflareAuthMiddleware)
+
+    # Security middleware (headers, rate limiting, SSRF prevention). CORS is
+    # intentionally NOT delegated here to avoid a second, conflicting layer;
+    # see middleware.security.add_security_middleware.
+    security_config = SecurityConfig(
+        enable_rate_limiting=settings.rate_limiting_enabled,
+        rate_limit_rpm=settings.rate_limit_rpm,
+        trust_proxy_headers=settings.rate_limit_trust_proxy,
+        client_ip_header=settings.rate_limit_client_ip_header,
+    )
+    add_security_middleware(app, security_config)
+
+    # Routers
+    app.include_router(health_router)
+    app.include_router(user_router, prefix=_API_V1_PREFIX)
+    app.include_router(ingest_router, prefix=_API_V1_PREFIX)
+    app.include_router(batch_router, prefix=_API_V1_PREFIX)
+    app.include_router(websocket_router)
+
+    # Wire the centralized exception hierarchy into the app so any
+    # ``ProjectBaseError`` is rendered with the mapped HTTP status.
+    app.add_exception_handler(ProjectBaseError, handle_project_error)  # type: ignore[arg-type]
+
+    app.add_api_route(
+        "/",
+        root,
+        methods=["GET"],
+        tags=["root"],
+        summary="API information",
+        description=(
+            "Returns basic API metadata including the service name, version, "
+            "and the path to the interactive OpenAPI docs. Requires Cloudflare "
+            "Access authentication when `CLOUDFLARE_ENABLED=true`."
+        ),
+    )
+    return app
+
+
+# Application instance for uvicorn (uvicorn rag_processor.main:app).
+app = create_app()
+
 # Export app for uvicorn
-__all__ = ["app"]
+__all__ = ["app", "create_app"]

--- a/src/rag_processor/middleware/security.py
+++ b/src/rag_processor/middleware/security.py
@@ -664,16 +664,24 @@ def add_security_middleware(app: FastAPI, config: SecurityConfig | None = None) 
             allowed_hosts=config.allowed_hosts,
         )
 
-    # CORS configuration (OWASP A05)
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=config.allowed_origins,
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
-        allow_headers=["*"],
-        expose_headers=["X-Request-ID"],
-        max_age=3600,
-    )
+    # CORS configuration (OWASP A05).
+    #
+    # CORS is only configured here when the caller explicitly supplies
+    # ``allowed_origins``. The main application owns CORS in
+    # ``rag_processor.main.create_app`` (driven by settings), so passing an
+    # empty list keeps this helper from registering a *second*, conflicting
+    # CORSMiddleware on top of it. Standalone users of this helper can still
+    # opt in by providing origins.
+    if config.allowed_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=config.allowed_origins,
+            allow_credentials=True,
+            allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+            allow_headers=["*"],
+            expose_headers=["X-Request-ID"],
+            max_age=3600,
+        )
 
     # Security headers (OWASP A05, A03, A09)
     app.add_middleware(SecurityHeadersMiddleware)

--- a/src/rag_processor/websocket/bridge.py
+++ b/src/rag_processor/websocket/bridge.py
@@ -1,0 +1,208 @@
+"""Redis pub/sub -> WebSocket bridge.
+
+Background workers publish batch/job events to Redis pub/sub channels
+(``batch:{batch_id}:events``) via :mod:`rag_processor.websocket.events`. The API
+process, however, is what holds the live WebSocket connections in its in-process
+:data:`~rag_processor.websocket.connection_manager.connection_manager`.
+
+This module provides the missing link: an :class:`EventBridge` that subscribes
+to the event channels and relays every message to the locally connected clients
+for the relevant batch. Without it, events would be published but never reach
+the browser.
+
+The bridge degrades gracefully: if Redis is unavailable at startup the bridge
+logs a warning and stays disabled rather than crashing the application.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import TYPE_CHECKING, Any
+
+from redis import asyncio as aioredis
+from redis.exceptions import RedisError
+
+from rag_processor.core.config import settings
+from rag_processor.utils.logging import get_logger
+from rag_processor.websocket.connection_manager import connection_manager
+
+if TYPE_CHECKING:
+    from redis.asyncio.client import PubSub
+
+logger = get_logger(__name__)
+
+# Glob pattern matching every per-batch event channel.
+EVENT_CHANNEL_PATTERN = "batch:*:events"
+
+
+class EventBridge:
+    """Relays Redis pub/sub batch events to local WebSocket connections.
+
+    Example:
+        bridge = EventBridge()
+        await bridge.start()
+        ...
+        await bridge.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 30.0,
+    ) -> None:
+        """Initialize the bridge in a stopped state.
+
+        Args:
+            initial_backoff: Initial delay (seconds) before the first reconnect
+                attempt after a listener error.
+            max_backoff: Upper bound (seconds) on the exponential reconnect
+                backoff.
+        """
+        self._redis: aioredis.Redis | None = None
+        self._pubsub: PubSub | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self._initial_backoff = initial_backoff
+        self._max_backoff = max_backoff
+
+    @property
+    def running(self) -> bool:
+        """Whether the bridge is actively listening for events.
+
+        Returns:
+            True while the listener task is active, False otherwise.
+        """
+        return self._running
+
+    async def start(self) -> None:
+        """Subscribe to event channels and begin relaying messages.
+
+        Safe to call when Redis is unavailable: failures are logged and the
+        bridge remains disabled instead of propagating the error. Once started,
+        transient Redis outages are handled by the listener, which reconnects
+        with bounded exponential backoff (see :meth:`_listen`).
+        """
+        try:
+            await self._subscribe()
+        except (RedisError, OSError) as e:
+            logger.warning(
+                "Event bridge disabled: could not subscribe to Redis events",
+                error=str(e),
+            )
+            await self._cleanup()
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._listen())
+        logger.info("Event bridge started", pattern=EVENT_CHANNEL_PATTERN)
+
+    async def stop(self) -> None:
+        """Stop relaying and release Redis resources."""
+        self._running = False
+
+        if self._task is not None:
+            self._task.cancel()
+            # Await the task so cancellation fully propagates. gather(...) with
+            # return_exceptions=True absorbs the resulting CancelledError instead
+            # of re-raising it here.
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+        await self._cleanup()
+        logger.info("Event bridge stopped")
+
+    async def _subscribe(self) -> PubSub:
+        """(Re)create the Redis client/pub-sub and subscribe to the pattern.
+
+        Returns:
+            The active pub/sub subscription.
+        """
+        if self._redis is None:
+            self._redis = aioredis.Redis(
+                host=settings.redis_host,
+                port=settings.redis_port,
+                password=settings.redis_password or None,
+                db=settings.redis_db,
+                decode_responses=True,
+            )
+        self._pubsub = self._redis.pubsub()
+        await self._pubsub.psubscribe(EVENT_CHANNEL_PATTERN)
+        return self._pubsub
+
+    async def _cleanup(self) -> None:
+        """Close the pub/sub subscription and Redis connection."""
+        if self._pubsub is not None:
+            with contextlib.suppress(RedisError, OSError):
+                await self._pubsub.punsubscribe(EVENT_CHANNEL_PATTERN)
+                await self._pubsub.aclose()
+            self._pubsub = None
+
+        if self._redis is not None:
+            with contextlib.suppress(RedisError, OSError):
+                await self._redis.aclose()
+            self._redis = None
+
+    async def _listen(self) -> None:
+        """Consume pub/sub messages and broadcast them to WebSocket clients.
+
+        Resilient to transient Redis outages: if the subscription drops, the
+        loop re-subscribes with bounded exponential backoff instead of exiting
+        permanently, so clients resume receiving events once Redis recovers.
+        The loop ends only when :meth:`stop` is called (which cancels the task).
+
+        Raises:
+            asyncio.CancelledError: Re-raised when :meth:`stop` cancels the
+                listener task, so cancellation propagates instead of being
+                swallowed by the reconnect handler.
+        """
+        backoff = self._initial_backoff
+        while self._running:
+            try:
+                pubsub = (
+                    self._pubsub
+                    if self._pubsub is not None
+                    else await self._subscribe()
+                )
+                async for message in pubsub.listen():
+                    if message.get("type") == "pmessage":
+                        await self._relay(message.get("data"))
+                    # Healthy activity resets the backoff window.
+                    backoff = self._initial_backoff
+            except asyncio.CancelledError:
+                raise
+            except (RedisError, OSError) as e:
+                if not self._running:
+                    break
+                logger.warning(
+                    "Event bridge listener error; reconnecting",
+                    error=str(e),
+                    retry_in_seconds=backoff,
+                )
+                # Drop the broken connection so the next iteration re-subscribes.
+                await self._cleanup()
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self._max_backoff)
+
+    async def _relay(self, raw: object) -> None:
+        """Parse a raw pub/sub payload and broadcast it to the batch's clients.
+
+        Args:
+            raw: The raw ``data`` field from a pub/sub message (JSON string).
+        """
+        if not isinstance(raw, str):
+            return
+
+        try:
+            event: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Event bridge received malformed event payload")
+            return
+
+        batch_id = event.get("batch_id")
+        if not batch_id:
+            return
+
+        await connection_manager.broadcast(str(batch_id), event)

--- a/src/rag_processor/websocket/bridge.py
+++ b/src/rag_processor/websocket/bridge.py
@@ -97,7 +97,29 @@ class EventBridge:
 
         self._running = True
         self._task = asyncio.create_task(self._listen())
+        self._task.add_done_callback(self._on_listener_done)
         logger.info("Event bridge started", pattern=EVENT_CHANNEL_PATTERN)
+
+    def _on_listener_done(self, task: asyncio.Task[None]) -> None:
+        """Surface an unexpected listener exit instead of failing silently.
+
+        A normal :meth:`stop` cancels the task or lets it return after
+        ``_running`` is cleared; both are expected. Any other exception means the
+        listener died unexpectedly, so record it and flip ``_running`` to False so
+        :attr:`running` stops reporting a false healthy state.
+
+        Args:
+            task: The completed listener task.
+        """
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self._running = False
+            logger.error(
+                "Event bridge listener exited unexpectedly",
+                error=repr(exc),
+            )
 
     async def stop(self) -> None:
         """Stop relaying and release Redis resources."""
@@ -135,8 +157,12 @@ class EventBridge:
     async def _cleanup(self) -> None:
         """Close the pub/sub subscription and Redis connection."""
         if self._pubsub is not None:
+            # Separate suppress blocks: if punsubscribe raises (the Redis-outage
+            # case this runs in), aclose must still run, otherwise the connection
+            # handle leaks on every reconnect cycle.
             with contextlib.suppress(RedisError, OSError):
                 await self._pubsub.punsubscribe(EVENT_CHANNEL_PATTERN)
+            with contextlib.suppress(RedisError, OSError):
                 await self._pubsub.aclose()
             self._pubsub = None
 
@@ -167,10 +193,24 @@ class EventBridge:
                     else await self._subscribe()
                 )
                 async for message in pubsub.listen():
-                    if message.get("type") == "pmessage":
+                    if message.get("type") != "pmessage":
+                        continue
+                    try:
                         await self._relay(message.get("data"))
-                    # Healthy activity resets the backoff window.
-                    backoff = self._initial_backoff
+                    except Exception:
+                        # Resilience boundary: a single bad event (or a client
+                        # disconnect during broadcast) must not tear down the
+                        # listener. Log and keep consuming so live delivery
+                        # survives. CancelledError is a BaseException and is not
+                        # caught here, so stop() still cancels cleanly.
+                        logger.exception(
+                            "Event bridge failed to relay a message; dropping it",
+                        )
+                    else:
+                        # Only a cleanly relayed event resets the backoff window;
+                        # a subscription ack alone is not evidence of a healthy
+                        # data path.
+                        backoff = self._initial_backoff
             except asyncio.CancelledError:
                 raise
             except (RedisError, OSError) as e:
@@ -196,10 +236,18 @@ class EventBridge:
             return
 
         try:
-            event: dict[str, Any] = json.loads(raw)
+            parsed: object = json.loads(raw)
         except json.JSONDecodeError:
             logger.warning("Event bridge received malformed event payload")
             return
+
+        # A syntactically valid JSON document can still decode to a non-object
+        # (number, array, string, null). Guard before treating it as a mapping so
+        # a stray payload cannot raise AttributeError and kill the listener task.
+        if not isinstance(parsed, dict):
+            logger.warning("Event bridge received non-object event payload")
+            return
+        event: dict[str, Any] = parsed
 
         batch_id = event.get("batch_id")
         if not batch_id:

--- a/src/rag_processor/websocket/connection_manager.py
+++ b/src/rag_processor/websocket/connection_manager.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fastapi import WebSocketDisconnect
+
 from rag_processor.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -124,7 +126,10 @@ class ConnectionManager:
             try:
                 await websocket.send_json(message)
                 sent_count += 1
-            except (RuntimeError, OSError) as e:
+            except (RuntimeError, OSError, WebSocketDisconnect) as e:
+                # WebSocketDisconnect subclasses only Exception (not OSError), so
+                # without it an abrupt client disconnect mid-broadcast would abort
+                # delivery to the remaining clients and propagate to callers.
                 logger.warning(
                     "Failed to send WebSocket message",
                     batch_id=batch_key,

--- a/tests/integration/test_app_lifespan.py
+++ b/tests/integration/test_app_lifespan.py
@@ -1,0 +1,26 @@
+"""Integration test for the application lifespan wiring of the event bridge.
+
+Lives in the integration tier because it boots the full FastAPI app via
+``TestClient`` (which runs the lifespan handler) rather than exercising the
+:class:`EventBridge` in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rag_processor.main import app
+from rag_processor.websocket.bridge import EventBridge
+
+
+@pytest.mark.integration
+class TestAppLifespanStartsBridge:
+    """The application lifespan starts and stops the event bridge."""
+
+    def test_lifespan_runs_bridge_start_and_stop(self) -> None:
+        """Entering/exiting the app context triggers bridge startup and shutdown."""
+        # Using TestClient as a context manager runs the lifespan handler.
+        with TestClient(app) as client:
+            assert client.get("/health/live").status_code == 200
+            assert isinstance(app.state.event_bridge, EventBridge)

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -1,0 +1,42 @@
+"""Unit tests for the application factory ``create_app``.
+
+Guards the wiring that ``create_app`` performs, in particular the proxy-aware
+rate-limiting configuration that must be passed through to ``SecurityConfig``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import rag_processor.main as main_module
+from rag_processor.core.config import settings
+
+
+@pytest.mark.unit
+class TestCreateAppSecurityWiring:
+    """The factory must forward proxy-aware rate-limiting settings."""
+
+    def test_create_app_passes_proxy_rate_limit_settings(self) -> None:
+        """``create_app`` wires trust_proxy_headers and client_ip_header.
+
+        Regression: an earlier app-factory refactor dropped these two kwargs,
+        silently reverting per-IP rate limiting to keying on the proxy IP behind
+        Cloudflare. ``create_app`` must always forward both from settings.
+        """
+        # wraps=... keeps the real SecurityConfig behavior so the rest of
+        # create_app (middleware registration) still runs, while recording the
+        # call so we can assert the proxy kwargs were forwarded.
+        real_security_config = main_module.SecurityConfig
+        with patch.object(
+            main_module,
+            "SecurityConfig",
+            wraps=real_security_config,
+        ) as spy:
+            main_module.create_app()
+
+        spy.assert_called_once()
+        kwargs = spy.call_args.kwargs
+        assert kwargs["trust_proxy_headers"] == settings.rate_limit_trust_proxy
+        assert kwargs["client_ip_header"] == settings.rate_limit_client_ip_header

--- a/tests/unit/test_event_bridge.py
+++ b/tests/unit/test_event_bridge.py
@@ -1,0 +1,188 @@
+"""Unit tests for the Redis pub/sub -> WebSocket :class:`EventBridge`.
+
+These tests verify the bridge correctly relays well-formed events to the
+connection manager, ignores malformed/irrelevant payloads, and starts/stops
+gracefully even when Redis is unavailable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rag_processor.websocket.bridge import EventBridge
+
+
+@pytest.mark.unit
+class TestEventBridgeRelay:
+    """Tests for payload parsing and relaying to the connection manager."""
+
+    @pytest.mark.asyncio
+    async def test_relay_broadcasts_well_formed_event(self) -> None:
+        """A valid event payload is broadcast to its batch's connections."""
+        bridge = EventBridge()
+        event = {
+            "event_type": "job_completed",
+            "batch_id": "11111111-1111-1111-1111-111111111111",
+            "job_id": "22222222-2222-2222-2222-222222222222",
+            "status": "completed",
+            "data": {"filename": "doc.pdf"},
+        }
+
+        with patch(
+            "rag_processor.websocket.bridge.connection_manager.broadcast",
+            new=AsyncMock(return_value=1),
+        ) as mock_broadcast:
+            await bridge._relay(json.dumps(event))
+
+        mock_broadcast.assert_awaited_once()
+        args = mock_broadcast.await_args.args
+        assert args[0] == event["batch_id"]
+        assert args[1]["event_type"] == "job_completed"
+
+    @pytest.mark.asyncio
+    async def test_relay_ignores_non_string_payload(self) -> None:
+        """Non-string payloads (e.g. None) are ignored without broadcasting."""
+        bridge = EventBridge()
+        with patch(
+            "rag_processor.websocket.bridge.connection_manager.broadcast",
+            new=AsyncMock(),
+        ) as mock_broadcast:
+            await bridge._relay(None)
+
+        mock_broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_relay_ignores_malformed_json(self) -> None:
+        """Malformed JSON is logged and ignored, never broadcast."""
+        bridge = EventBridge()
+        with patch(
+            "rag_processor.websocket.bridge.connection_manager.broadcast",
+            new=AsyncMock(),
+        ) as mock_broadcast:
+            await bridge._relay("{not valid json")
+
+        mock_broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_relay_ignores_event_without_batch_id(self) -> None:
+        """An event lacking a batch_id cannot be routed and is dropped."""
+        bridge = EventBridge()
+        with patch(
+            "rag_processor.websocket.bridge.connection_manager.broadcast",
+            new=AsyncMock(),
+        ) as mock_broadcast:
+            await bridge._relay(json.dumps({"status": "ok"}))
+
+        mock_broadcast.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestEventBridgeLifecycle:
+    """Tests for graceful start/stop behavior."""
+
+    @pytest.mark.asyncio
+    async def test_start_degrades_gracefully_when_redis_unavailable(self) -> None:
+        """If subscribing raises, the bridge stays disabled and does not raise."""
+        with patch("rag_processor.websocket.bridge.aioredis.Redis") as mock_redis_cls:
+            mock_client = mock_redis_cls.return_value
+            mock_client.pubsub.side_effect = OSError("redis down")
+            mock_client.aclose = AsyncMock()
+
+            bridge = EventBridge()
+            await bridge.start()
+
+        assert bridge.running is False
+        # stop() on a never-started bridge must be safe.
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_listen_relay_stop_end_to_end(self) -> None:
+        """A published event is consumed by the listener and broadcast, then stop() cleans up."""
+        from fakeredis import FakeServer
+        from fakeredis.aioredis import FakeRedis
+
+        server = FakeServer()
+
+        def _fake_redis(*_args: object, **_kwargs: object) -> FakeRedis:
+            return FakeRedis(server=server, decode_responses=True)
+
+        with (
+            patch(
+                "rag_processor.websocket.bridge.aioredis.Redis",
+                side_effect=_fake_redis,
+            ),
+            patch(
+                "rag_processor.websocket.bridge.connection_manager.broadcast",
+                new=AsyncMock(return_value=1),
+            ) as mock_broadcast,
+        ):
+            bridge = EventBridge()
+            await bridge.start()
+            assert bridge.running is True
+
+            publisher = FakeRedis(server=server, decode_responses=True)
+            await publisher.publish(
+                "batch:xyz:events",
+                json.dumps({"batch_id": "xyz", "event_type": "job_completed"}),
+            )
+
+            # Give the listener task time to receive and relay the message.
+            for _ in range(50):
+                if mock_broadcast.await_count:
+                    break
+                await asyncio.sleep(0.02)
+
+            await publisher.aclose()
+            await bridge.stop()
+
+        mock_broadcast.assert_awaited()
+        assert mock_broadcast.await_args.args[0] == "xyz"
+        assert bridge.running is False
+
+    @pytest.mark.asyncio
+    async def test_listen_reconnects_after_transient_error(self) -> None:
+        """A transient listener error triggers re-subscribe and resumed relaying."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        bridge = EventBridge(initial_backoff=0, max_backoff=0)
+        bridge._running = True
+
+        class _FlakyPubSub:
+            """First listen() drops the connection; the second relays one event."""
+
+            def __init__(self) -> None:
+                self.attempt = 0
+
+            async def listen(self):
+                self.attempt += 1
+                if self.attempt == 1:
+                    raise RedisConnectionError("connection dropped")
+                yield {
+                    "type": "pmessage",
+                    "data": json.dumps(
+                        {"batch_id": "b1", "event_type": "job_completed"}
+                    ),
+                }
+                # Stop the loop after the first successful relay.
+                bridge._running = False
+
+        fake = _FlakyPubSub()
+
+        with (
+            patch.object(bridge, "_subscribe", new=AsyncMock(return_value=fake)),
+            patch.object(bridge, "_cleanup", new=AsyncMock()),
+            patch(
+                "rag_processor.websocket.bridge.connection_manager.broadcast",
+                new=AsyncMock(return_value=1),
+            ) as mock_broadcast,
+        ):
+            await bridge._listen()
+
+        # Despite the first-attempt failure, the event was relayed after retry.
+        mock_broadcast.assert_awaited_once()
+        assert mock_broadcast.await_args.args[0] == "b1"
+        assert fake.attempt == 2

--- a/tests/unit/test_event_bridge.py
+++ b/tests/unit/test_event_bridge.py
@@ -79,6 +79,33 @@ class TestEventBridgeRelay:
 
         mock_broadcast.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            json.dumps([1, 2, 3]),
+            json.dumps(5),
+            json.dumps("just a string"),
+            json.dumps(None),
+        ],
+    )
+    async def test_relay_ignores_valid_non_dict_json(self, payload: str) -> None:
+        """Valid JSON that is not an object is dropped without raising.
+
+        Regression: json.loads can return a list/int/str/None; calling .get()
+        on those raises AttributeError, which is not caught by the listener and
+        would permanently kill it. The relay must drop non-object payloads.
+        """
+        bridge = EventBridge()
+        with patch(
+            "rag_processor.websocket.bridge.connection_manager.broadcast",
+            new=AsyncMock(),
+        ) as mock_broadcast:
+            # Must not raise.
+            await bridge._relay(payload)
+
+        mock_broadcast.assert_not_awaited()
+
 
 @pytest.mark.unit
 class TestEventBridgeLifecycle:

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import WebSocketDisconnect
 
 from rag_processor.models.batch import Batch, BatchStatus
 from rag_processor.websocket.connection_manager import ConnectionManager
@@ -152,6 +153,36 @@ class TestConnectionManager:
         # One succeeded, one failed
         assert sent_count == 1
         # Failed connection should be removed
+        assert manager.get_connection_count(batch_id) == 1
+
+    @pytest.mark.asyncio
+    async def test_broadcast_tolerates_client_disconnect(
+        self, manager: ConnectionManager
+    ) -> None:
+        """An abrupt client disconnect mid-broadcast is handled, not propagated.
+
+        Regression: WebSocketDisconnect subclasses only Exception (not OSError),
+        so a disconnect raised by send_json must be caught explicitly. Otherwise
+        it aborts delivery to the remaining clients and propagates to the caller
+        (e.g. the event bridge listener), killing real-time delivery.
+        """
+        batch_id = uuid4()
+
+        ws1 = MagicMock()
+        ws1.accept = AsyncMock()
+        ws1.send_json = AsyncMock(side_effect=WebSocketDisconnect(code=1006))
+        ws2 = MagicMock()
+        ws2.accept = AsyncMock()
+        ws2.send_json = AsyncMock()
+
+        await manager.connect(ws1, batch_id)
+        await manager.connect(ws2, batch_id)
+
+        # Must not raise even though ws1 disconnects during send.
+        sent_count = await manager.broadcast(batch_id, {"type": "test"})
+
+        # ws2 still received the message; ws1 was pruned.
+        assert sent_count == 1
         assert manager.get_connection_count(batch_id) == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Salvages the four deliverables from **closed #60** that the broader **merged #61** did not cover. #60 and #61 were two attempts at the same architecture review; #61 landed first and superseded #60's headline ingest-pipeline wiring, but three to four of #60's pieces never reached `main`. #60 was closed as superseded; this PR rebuilds its unique parts against current `main` (post-#61) rather than rebasing, since #60 conflicted in `ingest.py`, `config.py`, `main.py`, `queue/jobs.py`, and `websocket/events.py`.

## What changed

### 1. Real-time WebSocket event delivery (the main gap)
`websocket/bridge.py` adds an `EventBridge` that subscribes to the Redis `batch:*:events` pub/sub channels and relays each event to the locally connected WebSocket clients. It is started/stopped in the app lifespan, degrades gracefully when Redis is unavailable, and reconnects with bounded exponential backoff after transient outages.

Before this, workers published events to Redis but **nothing consumed them** for live clients (`main` had no subscriber); browsers saw only the initial snapshot and `last_event_id` replay.

### 2. Application factory + dependency injection
`main.py` now exposes `create_app()` as the single source of truth for middleware ordering and CORS (module-level `app = create_app()`). `FileRouter` is injected via `Depends(get_file_router)` (new `api/dependencies.py`) instead of an import-time global, giving tests an override seam. #61's `ProjectBaseError` exception handler and Redis pool shutdown are preserved (merged in, not dropped).

### 3. CORS de-duplication (security)
`add_security_middleware` no longer registers a second, conflicting `CORSMiddleware` (empty origins, `allow_headers=["*"]`) on top of the app's. It now configures CORS only when the caller explicitly supplies `allowed_origins`; `create_app` owns CORS for the gateway.

### 4. docker-compose Redis wiring
The `app` and `worker` services only received `REDIS_URL`/`LOG_LEVEL`, but the code reads the `RAG_PROCESSOR_`-prefixed settings, so both silently fell back to `redis_host=localhost` and never reached the `redis` service. Added `RAG_PROCESSOR_REDIS_*` (plus log/enqueue) to both services and switched the worker to the `rq worker` console script.

## Verification

| Check | Result |
|---|---|
| Tests | **467 passed**, 1 pre-existing skip (+2 new test files) |
| Coverage | 92.43% (>=80 gate); `bridge.py` 97%, `main.py` 95% |
| `ruff check` / `ruff format` | clean |
| `basedpyright src/` | 0 errors |
| `bandit -r src` | 0 high/critical (pre-existing low/medium only) |
| `pre-commit run` (staged) | all hooks pass |
| Dependencies | none added; `uv.lock` unchanged |

## Notes

- The dummy local-dev Postgres credential in `docker-compose.yml` is annotated `trufflehog:ignore` (documented false positive), unrelated to the Redis changes.
- Out of scope (same as flagged in the original review): remaining dead subsystems, blocking pdfplumber/`magic` on the async path, in-memory rate-limit/WS state under multi-worker scaling, placeholder readiness probe.

Refs #60, #61
