### PR TITLE
refactor: remove duplicate get_file_router DI provider

### DIFF
--- a/src/rag_processor/routing/__init__.py
+++ b/src/rag_processor/routing/__init__.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 from rag_processor.routing.classifier import FileClassifier
 from rag_processor.routing.detector import FileTypeDetector
-from rag_processor.routing.router import FileRouter, file_router, get_file_router
+from rag_processor.routing.router import FileRouter
 
 __all__ = [
     "FileClassifier",
     "FileRouter",
     "FileTypeDetector",
-    "file_router",
-    "get_file_router",
 ]

--- a/src/rag_processor/routing/router.py
+++ b/src/rag_processor/routing/router.py
@@ -147,20 +147,3 @@ class FileRouter:
         """
         pipeline = self._routing.get(classification, Pipeline.NONE)
         return pipeline != Pipeline.NONE
-
-
-# Module-level shared instance used by the API layer.
-file_router = FileRouter()
-
-
-def get_file_router() -> FileRouter:
-    """FastAPI dependency returning the shared FileRouter instance.
-
-    Using a dependency (rather than referencing the module-level singleton
-    directly in handlers) lets callers and tests override routing via
-    ``app.dependency_overrides`` without monkeypatching module globals.
-
-    Returns:
-        The shared FileRouter singleton.
-    """
-    return file_router

--- a/tests/unit/test_routing_config.py
+++ b/tests/unit/test_routing_config.py
@@ -1,9 +1,8 @@
-"""Tests for configurable classification thresholds and FileRouter DI."""
+"""Tests for configurable classification thresholds."""
 
 from __future__ import annotations
 
 from rag_processor.core.config import settings
-from rag_processor.routing import FileRouter, file_router, get_file_router
 from rag_processor.routing.classifier import FileClassifier
 
 
@@ -31,11 +30,3 @@ class TestClassifierThresholds:
         assert clf._scanned_chars_threshold == 5
         assert clf._scanned_high_confidence_chars == 2
         assert clf._digital_high_confidence_chars == 500
-
-
-class TestFileRouterDependency:
-    """get_file_router exposes the shared singleton for DI/overrides."""
-
-    def test_returns_shared_singleton(self) -> None:
-        assert get_file_router() is file_router
-        assert isinstance(get_file_router(), FileRouter)


### PR DESCRIPTION
## Summary

PR #63 and #68 each independently added a `get_file_router` FastAPI dependency, in **different modules**. #68 (merged first) placed it in `api/dependencies.py`; #63 added a second copy in `routing/router.py` backed by a module-level `file_router` singleton. After #63 merged, both now live on `main`, so the same DI provider exists twice.

This consolidates on the `api/dependencies.py` version (the one the ingest handler already imports) and removes the duplicate.

## Changes

- Remove the `file_router` singleton and `get_file_router` from `routing/router.py`
- Drop their exports from `routing/__init__.py` (`__all__`)
- Remove the now-redundant `TestFileRouterDependency` test from `test_routing_config.py`

## Why

Both PRs derived this DI helper from the same closed #60 work, so the duplication is an artifact of parallel salvage branches, not an intentional two-provider design. The surviving `api/dependencies.get_file_router` returns a process-wide `FileRouter` and is overridable via `app.dependency_overrides`, so there is no behavior change.

## Verification

- ruff check + format: clean
- basedpyright (strict): 0 errors
- pytest: 496 passed, 1 skipped (pre-existing, #44), coverage 93.04%

Net diff: 3 files, +2/-30.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the routing module's internal structure and public exports for improved maintainability.

* **Tests**
  * Updated routing configuration tests to focus on classifier threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->