### PR TITLE
ci: emit on merge_group for required-check callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@
 name: CI
 
 on:
+  merge_group:
   push:
     branches: [main, master, develop]
   pull_request:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,7 @@
 name: PR Validation
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
@@ -13,9 +14,9 @@ on:
       - master
       - develop
 
-# Cancel in-progress runs for same PR
+# Cancel in-progress runs for same PR or merge-queue ref
 concurrency:
-  group: pr-validation-${{ github.event.pull_request.number }}
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,7 @@
 name: REUSE Compliance
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -9,6 +9,7 @@
 name: Security Analysis
 
 "on":
+  merge_group:
   push:
     branches: [main, master]
   pull_request:


### PR DESCRIPTION
## What

Adds `merge_group:` to the four workflows that produce rag-processor's required status checks, so they report inside the GitHub merge queue:

| Required check | Caller workflow |
| --- | --- |
| CI Gate | `.github/workflows/ci.yml` |
| Security Analysis / Security Gate Validation | `.github/workflows/security-analysis.yml` |
| Dependency & Standards Validation | `.github/workflows/pr-validation.yml` |
| Check REUSE Compliance | `.github/workflows/reuse.yml` |

Also updates `pr-validation.yml`'s concurrency group to fall back to `github.ref` when there is no PR number, so queued entries do not cancel one another.

## Why

This is Step 1 (CI-040) of enabling a merge queue on rag-processor, the next repo in the Renovate-automerge merge-queue rollout after the gleif canary and the `.github` org-config repo. A merge queue serializes and re-tests entries; required checks that only trigger on `pull_request` never report on the `merge_group` ref and the queue waits until the 60-minute timeout. Adding `merge_group` triggers fixes that.

Step 2 (POST a repo-level `rag-processor-merge-queue` ruleset, CI-062) happens only after this merges, per the sequenced rollout (workflow PR -> merge -> enable rule -> observe one cycle).

## Safety

- The three reusable-workflow callers (`ci`, `security`, `core-validation`) were already proven to run on `merge_group` via the gleif canary.
- No `run:` step consumes PR-only context; the only `pull_request.number` use was the concurrency expression, now guarded with `|| github.ref`.
- `merge_group` trigger form matches the verified-green gleif workflows.

Refs: CI-040, CI-062.
