### PR TITLE
ci: add Claude Tier 0 baseline PR review caller

### DIFF
--- a/.github/workflows/claude-baseline-review.yml
+++ b/.github/workflows/claude-baseline-review.yml
@@ -1,0 +1,59 @@
+# ============================================================================
+# Claude Baseline Review -- caller for the rag-processor repo
+# ============================================================================
+# Thin caller for the Tier 0 baseline reviewer. The reviewer logic, security
+# posture, and prompt live in the reusable workflow in ByronWilliamsCPA/.github;
+# this file only supplies the trigger, the permission ceiling, and this repo's
+# framing. Part of the tiered-pr-review fleet rollout.
+#
+# #CRITICAL: a called (reusable) workflow runs with a token bounded by the
+# CALLER job's permissions. The four scopes below are the ceiling the reusable
+# needs (id-token for the Claude App OIDC exchange); omitting any one fails the
+# run at startup.
+# #CRITICAL: do NOT add a workflow-level `concurrency` block here. The reusable
+# already declares one; a caller block resolves to the same group for a
+# pull_request event, and a called workflow that shares its caller's
+# concurrency group cancels its own parent, failing the run at startup.
+# ============================================================================
+name: Claude Baseline Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    # #VERIFY before bumping the pin: the target SHA must stay reachable from
+    # ByronWilliamsCPA/.github main. `gh api
+    # repos/ByronWilliamsCPA/.github/compare/main...<sha> --jq .status` must not
+    # return "diverged". Renovate tracks this pin.
+    uses: ByronWilliamsCPA/.github/.github/workflows/claude-baseline-review.yml@8de6560ef6089fa95d56c77186648186dac6ce26  # main
+    with:
+      repo-description: >-
+        a React frontend with FastAPI backend integration for a RAG
+        pipeline.
+      sensitive-paths: >-
+        .github/workflows/, pyproject.toml, package.json, src/, scripts/
+      escalation-guidance: |
+        - Changes to .github/workflows/ that touch permissions:, secrets,
+          id-token, or on: triggers.
+        - Changes to dependency manifests (pyproject.toml, requirements files,
+          package.json, lockfiles) that add or change a dependency source.
+        - Changes that touch secret handling, authentication, or credential
+          storage.
+        - Changes under scripts/ that perform writes via gh api, handle secrets,
+          or transfer or delete resources.
+    # Least-privilege: pass only the one secret the reusable declares in its
+    # workflow_call.secrets contract (ANTHROPIC_API_KEY, required: true), rather
+    # than forwarding every inherited secret via `secrets: inherit`.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # pragma: allowlist secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI: Claude Tier 0 baseline PR review caller (`.github/workflows/claude-baseline-review.yml`), a thin caller of the org reusable in `ByronWilliamsCPA/.github`. Part of the org-wide tiered-pr-review rollout.
+
 ### Changed
 
 - **Renovate covers the npm frontend**: added `npm` to `enabledManagers` in


### PR DESCRIPTION
## Summary

Adds the Tier 0 Claude baseline PR reviewer as a thin caller of the org reusable workflow in ByronWilliamsCPA/.github. Part of the org-wide tiered-pr-review rollout.

- Pinned to a reachable .github main SHA (8de6560); Renovate-tracked.
- Explicit ANTHROPIC_API_KEY mapping (least-privilege), not secrets: inherit.
- No caller-level concurrency block (the reusable owns concurrency; a caller block would deadlock at startup).

The Claude GitHub App is installed org-wide and ANTHROPIC_API_KEY is an org secret (visibility: all), so no per-repo setup is required.

## Verification

This PR adds the reviewer's own workflow file, so the action's tamper guard will skip the actual review on this PR; the signal is that the run reaches a job (skip) rather than a zero-job startup failure.
