### PR TITLE
fix(ci): wire required checks for the merge queue

### DIFF
--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -58,3 +58,32 @@ jobs:
       # rag-processor uses hatchling as build backend, so editable installs
       # require the build step. The reusable defaults no-build: true; override.
       no-build: false
+
+  # Bare "Security Gate Validation" context required by the org ruleset.
+  # The reusable security workflow surfaces as
+  # "Security Analysis / Security Gate Validation" (caller / reusable job),
+  # which cannot match the bare ruleset context. This in-line aggregator
+  # re-emits the bare context on pull_request and inside the merge queue.
+  security-gate:
+    name: Security Gate Validation
+    runs-on: ubuntu-latest
+    needs: [security]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: ''
+      - name: Aggregate security result
+        run: |
+          result="${{ needs.security.result }}"
+          if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+            echo "Security Gate Validation: passed (result: $result)"
+          else
+            echo "::error::Security Gate Validation failed: $result"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a bare `Security Gate Validation` aggregator job to `security-analysis.yml` (which already triggers on `merge_group`). The reusable security workflow only emitted `Security Analysis / Security Gate Validation` (caller/callee form), which never matched the bare required context, so that check was unsatisfiable on every PR, not just in the queue. The other three required checks were already wired correctly.

## Files changed

- `.github/workflows/security-analysis.yml`

## Why

GitHub merge queues dispatch a `merge_group` event, not `pull_request`. A
required status check whose workflow does not trigger on `merge_group` never
reports on the queued commit, so the entry waits the full timeout and fails.
Required checks produced by reusable workflows surface as `caller-job /
callee-job`, which cannot match a bare ruleset context; the org pattern is an
in-line aggregator job named exactly the bare context.

## Landing this PR (deadlock)

For `merge_group` events GitHub uses the workflow definition from the default
branch, so this fix does not take effect in the queue until it is on `main`.
This repo's merge-queue ruleset has no bypass actor, so an admin must break the
deadlock once: temporarily set the `merge-queue` ruleset to **Evaluate** (or
Disabled), squash-merge this PR, then re-enable. Subsequent PRs drain normally.

## Validation

`actionlint` and `yamllint` (repo config) pass on the changed files; no new
findings introduced. Generated as part of an org-wide read-only audit.
